### PR TITLE
Issue 55 enable nullability annotation based schema generator

### DIFF
--- a/LateApexEarlySpeed.Json.Schema/Generator/AnnotationBasedNullabilityPolicy.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/AnnotationBasedNullabilityPolicy.cs
@@ -1,0 +1,14 @@
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator;
+
+public class AnnotationBasedNullabilityPolicy : NullabilityPolicy
+{
+    protected internal override bool UseNullabilityAnnotation => true;
+
+    protected internal override NullabilityState GetNullabilityState(IMemberInfo memberInfo)
+    {
+        return ((NullabilityTypeWrapper)memberInfo.GetMemberType()).NullabilityState;
+    }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/AttributeBasedNullabilityPolicy.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/AttributeBasedNullabilityPolicy.cs
@@ -1,0 +1,13 @@
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Nullability.Generic;
+using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator;
+
+public class AttributeBasedNullabilityPolicy : NullabilityPolicy
+{
+    protected internal override NullabilityState GetNullabilityState(IMemberInfo memberInfo)
+    {
+        return memberInfo.MemberInfo.GetCustomAttribute<NotNullAttribute>() is null ? NullabilityState.Unknown : NullabilityState.NotNull;
+    }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/NullabilityPolicy.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/NullabilityPolicy.cs
@@ -1,0 +1,13 @@
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator;
+
+public abstract class NullabilityPolicy
+{
+    public static NullabilityPolicy BasedOnAttribute { get; } = new AttributeBasedNullabilityPolicy();
+    public static NullabilityPolicy BasedOnNullabilityAnnotation { get; } = new AnnotationBasedNullabilityPolicy();
+
+    protected internal virtual bool UseNullabilityAnnotation => false;
+    protected internal abstract NullabilityState GetNullabilityState(IMemberInfo memberInfo);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/NullabilityPolicy.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/NullabilityPolicy.cs
@@ -5,7 +5,14 @@ namespace LateApexEarlySpeed.Json.Schema.Generator;
 
 public abstract class NullabilityPolicy
 {
+    /// <summary>
+    /// Gets the nullability policy for <see cref="NotNullAttribute"/> based policy
+    /// </summary>
     public static NullabilityPolicy BasedOnAttribute { get; } = new AttributeBasedNullabilityPolicy();
+
+    /// <summary>
+    /// Gets the nullability policy for nullability annotation based policy
+    /// </summary>
     public static NullabilityPolicy BasedOnNullabilityAnnotation { get; } = new AnnotationBasedNullabilityPolicy();
 
     protected internal virtual bool UseNullabilityAnnotation => false;

--- a/LateApexEarlySpeed.Json.Schema/Generator/NullabilityTypeInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/NullabilityTypeInfo.cs
@@ -1,0 +1,11 @@
+﻿using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator;
+
+public class NullabilityTypeInfo
+{
+    public NullabilityElement? ArrayElementNullability { get; set; }
+    public NullabilityElement[]? GenericTypeArgumentsNullabilities { get; set; }
+
+    public NullabilityPolicy ReferenceTypeNullabilityPolicy { get; set; } = NullabilityPolicy.BasedOnAttribute;
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/NullabilityTypeInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/NullabilityTypeInfo.cs
@@ -7,5 +7,8 @@ public class NullabilityTypeInfo
     public NullabilityElement? ArrayElementNullability { get; set; }
     public NullabilityElement[]? GenericTypeArgumentsNullabilities { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value that specifies the policy used to decide reference type property or field's nullability on an object, such as by <see cref="NotNullAttribute"/> or by nullability annotation.
+    /// </summary>
     public NullabilityPolicy ReferenceTypeNullabilityPolicy { get; set; } = NullabilityPolicy.BasedOnAttribute;
 }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ArbitraryJsonTypesSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ArbitraryJsonTypesSchemaGenerationCandidate.cs
@@ -2,6 +2,7 @@
 using LateApexEarlySpeed.Json.Schema.Keywords;
 using System.Text.Json.Nodes;
 using System.Text.Json;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
@@ -12,7 +13,7 @@ internal class ArbitraryJsonTypesSchemaGenerationCandidate : ISchemaGenerationCa
         return typeToConvert == typeof(JsonElement) || typeToConvert == typeof(JsonDocument) || typeToConvert == typeof(JsonNode) || typeToConvert == typeof(JsonValue);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return new BodyJsonSchema(keywordsFromProperty);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/BooleanSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/BooleanSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class BooleanSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(bool);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return new BodyJsonSchema(keywordsFromProperty.Append(new TypeKeyword(InstanceType.Boolean)));
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ByteSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ByteSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class ByteSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(byte);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForUnsignedInteger(keywordsFromProperty, byte.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/CollectionSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/CollectionSchemaGenerationCandidate.cs
@@ -1,31 +1,51 @@
 ﻿using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 using System.Diagnostics;
+using System.Reflection;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
 internal class CollectionSchemaGenerationCandidate : ISchemaGenerationCandidate
 {
+    private readonly HashSet<Type> _supportedGenericInterfaceDefinitions = new()
+    {
+        typeof(IEnumerable<>),
+        typeof(ICollection<>),
+        typeof(IReadOnlyCollection<>),
+        typeof(IList<>),
+        typeof(IReadOnlyList<>)
+    };
+
     public bool CanGenerate(Type typeToConvert)
     {
-        return typeToConvert.GetInterface("IEnumerable`1") is not null;
+        if (typeToConvert.GetInterface("IEnumerable`1") is null)
+        {
+            return false;
+        }
+
+        if (!typeToConvert.IsInterface)
+        {
+            return true;
+        }
+
+        return typeToConvert.IsGenericType && _supportedGenericInterfaceDefinitions.Contains(typeToConvert.GetGenericTypeDefinition());
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         List<KeywordBase> keywords = new List<KeywordBase> { new TypeKeyword(InstanceType.Array, InstanceType.Null) };
         keywords.AddRange(keywordsFromProperty);
 
-        Debug.Assert(typeToConvert.GetInterface("IEnumerable`1") is not null);
-        Type elementType = typeToConvert.GetInterface("IEnumerable`1").GetGenericArguments()[0];
+        IType elementType = GetElementType(typeToConvert);
         JsonSchema elementSchema = JsonSchemaGenerator.GenerateSchema(elementType, Enumerable.Empty<KeywordBase>(), options);
 
         JsonSchema itemsSchema;
         if (elementSchema is JsonSchemaResource elementSchemaResource)
         {
-            options.SchemaDefinitions.AddSchemaDefinition(elementType, elementSchemaResource);
+            options.SchemaDefinitions.AddSchemaDefinition(elementType.Type, elementSchemaResource);
 
-            itemsSchema = SchemaGenerationHelper.GenerateSchemaReference(elementType, Enumerable.Empty<KeywordBase>(), options.MainDocumentBaseUri!);
+            itemsSchema = SchemaGenerationHelper.GenerateSchemaReference(elementType.Type, Enumerable.Empty<KeywordBase>(), options.MainDocumentBaseUri!);
         }
         else
         {
@@ -36,5 +56,33 @@ internal class CollectionSchemaGenerationCandidate : ISchemaGenerationCandidate
         keywords.Add(itemsKeyword);
 
         return new BodyJsonSchema(keywords);
+    }
+
+    private static IType GetElementType(IType typeToConvert)
+    {
+        Type type = typeToConvert.Type;
+
+        if (type.IsArray)
+        {
+            return typeToConvert.GetArrayElementType();
+        }
+
+        if (type.IsInterface)
+        {
+            Debug.Assert(typeToConvert.GenericTypeArguments.Length == 1);
+            return typeToConvert.GenericTypeArguments[0];
+        }
+
+        Type? enumerableInterface = type.GetInterface("IEnumerable`1");
+        Debug.Assert(enumerableInterface is not null);
+
+        InterfaceMapping interfaceMapping = type.GetInterfaceMap(enumerableInterface);
+        int getEnumeratorIdx = Array.IndexOf(interfaceMapping.InterfaceMethods, enumerableInterface.GetMethod(nameof(IEnumerable<int>.GetEnumerator)));
+        Debug.Assert(getEnumeratorIdx != -1);
+        MethodInfo getEnumeratorMethodInfo = interfaceMapping.TargetMethods[getEnumeratorIdx];
+
+        IMethodInfo getEnumerator = typeToConvert.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Single(method => method.MethodInfo == getEnumeratorMethodInfo);
+        IType enumeratorType = getEnumerator.ReturnParameter.ParameterType;
+        return enumeratorType.GenericTypeArguments[0];
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/CustomObjectSchemaGenerator.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/CustomObjectSchemaGenerator.cs
@@ -2,31 +2,32 @@
 using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 using LateApexEarlySpeed.Json.Schema.JInstance;
+using LateApexEarlySpeed.Nullability.Generic;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
 internal class CustomObjectSchemaGenerator : ISchemaGenerator
 {
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
-        TypeKeyword typeKeyword = typeToConvert.IsValueType
+        TypeKeyword typeKeyword = typeToConvert.Type.IsValueType
             ? new TypeKeyword(InstanceType.Object)
             : new TypeKeyword(InstanceType.Object, InstanceType.Null);
 
-        IEnumerable<KeywordBase> keywordsOnType = SchemaGenerationHelper.GenerateKeywordsFromType(typeToConvert);
+        IEnumerable<KeywordBase> keywordsOnType = SchemaGenerationHelper.GenerateKeywordsFromType(typeToConvert.Type);
 
-        PropertyInfo[] propertyInfos = typeToConvert.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        FieldInfo[] fieldInfos = typeToConvert.GetFields(BindingFlags.Public | BindingFlags.Instance);
+        IPropertyInfo[] propertyInfos = typeToConvert.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        IFieldInfo[] fieldInfos = typeToConvert.GetFields(BindingFlags.Public | BindingFlags.Instance);
 
-        IEnumerable<MemberInfo> memberInfos = propertyInfos.Concat<MemberInfo>(fieldInfos);
+        IEnumerable<IMemberInfo> memberInfos = propertyInfos.Concat<IMemberInfo>(fieldInfos);
 
         PropertiesKeyword propertiesKeyword = CreatePropertiesKeyword(memberInfos, options);
 
-        RequiredKeyword? requiredKeyword = CreateRequiredKeyword(memberInfos, options);
+        RequiredKeyword? requiredKeyword = CreateRequiredKeyword(memberInfos.Select(m => m.MemberInfo), options);
 
         IEnumerable<KeywordBase> keywords = keywordsOnType.Append(typeKeyword).Append(propertiesKeyword);
         if (requiredKeyword is not null)
@@ -34,39 +35,39 @@ internal class CustomObjectSchemaGenerator : ISchemaGenerator
             keywords = keywords.Append(requiredKeyword);
         }
 
-        return new JsonSchemaResource(new Uri(typeToConvert.FullName!, UriKind.Relative), keywords.ToList(), new List<ISchemaContainerValidationNode>(0), null, null, null, null, null);
+        return new JsonSchemaResource(new Uri(typeToConvert.Type.FullName!, UriKind.Relative), keywords.ToList(), new List<ISchemaContainerValidationNode>(0), null, null, null, null, null);
     }
 
-    private static PropertiesKeyword CreatePropertiesKeyword(IEnumerable<MemberInfo> memberInfos, JsonSchemaGeneratorOptions options)
+    private static PropertiesKeyword CreatePropertiesKeyword(IEnumerable<IMemberInfo> memberInfos, JsonSchemaGeneratorOptions options)
     {
         var propertiesSchemas = new Dictionary<string, JsonSchema>();
 
-        foreach (MemberInfo memberInfo in memberInfos.Where(prop => prop.GetCustomAttribute<JsonIgnoreAttribute>() is null))
+        foreach (IMemberInfo memberInfo in memberInfos.Where(prop => prop.MemberInfo.GetCustomAttribute<JsonIgnoreAttribute>() is null))
         {
-            Type memberType = GetMemberType(memberInfo);
+            IType memberType = memberInfo.GetMemberType();
 
             KeywordBase[] keywordsOfMember = GenerateKeywordsFromMemberInfo(memberInfo);
             JsonSchema propertySchema = JsonSchemaGenerator.GenerateSchema(memberType, keywordsOfMember, options);
 
             if (propertySchema is JsonSchemaResource propertySchemaResource)
             {
-                options.SchemaDefinitions.AddSchemaDefinition(memberType, propertySchemaResource);
+                options.SchemaDefinitions.AddSchemaDefinition(memberType.Type, propertySchemaResource);
 
-                propertySchema = SchemaGenerationHelper.GenerateSchemaReference(memberType, keywordsOfMember, options.MainDocumentBaseUri!);
+                propertySchema = SchemaGenerationHelper.GenerateSchemaReference(memberType.Type, keywordsOfMember, options.MainDocumentBaseUri!);
             }
 
             List<KeywordBase>? keywordsForAdditionalAttributes = null;
 
-            if (memberInfo.GetCustomAttribute<NotNullAttribute>() is not null)
+            if (options.NullabilityTypeInfo.ReferenceTypeNullabilityPolicy.GetNullabilityState(memberInfo) == NullabilityState.NotNull)
             {
                 var typeKeyword = new TypeKeyword(InstanceType.Object, InstanceType.String, InstanceType.Number, InstanceType.Boolean, InstanceType.Array);
                 keywordsForAdditionalAttributes = new List<KeywordBase>(2) { typeKeyword };
             }
 
-            if (memberType.IsEnum && EnumSchemaGenerationCandidate.HasJsonStringEnumConverter(memberInfo))
+            if (memberType.Type.IsEnum && EnumSchemaGenerationCandidate.HasJsonStringEnumConverter(memberInfo.MemberInfo))
             {
                 keywordsForAdditionalAttributes ??= new List<KeywordBase>(1);
-                keywordsForAdditionalAttributes.Add(new EnumKeyword(memberType.GetEnumNames().Select(JsonInstanceSerializer.SerializeToElement)));
+                keywordsForAdditionalAttributes.Add(new EnumKeyword(memberType.Type.GetEnumNames().Select(JsonInstanceSerializer.SerializeToElement)));
             }
 
             if (keywordsForAdditionalAttributes is not null)
@@ -76,7 +77,7 @@ internal class CustomObjectSchemaGenerator : ISchemaGenerator
                 propertySchema = new BodyJsonSchema(new KeywordBase[] { allOfKeyword });
             }
 
-            propertiesSchemas[GetPropertyName(memberInfo, options)] = propertySchema;
+            propertiesSchemas[GetPropertyName(memberInfo.MemberInfo, options)] = propertySchema;
         }
 
         return new PropertiesKeyword(propertiesSchemas, false);
@@ -104,23 +105,9 @@ internal class CustomObjectSchemaGenerator : ISchemaGenerator
     /// <summary>
     /// Extract attributes from either <see cref="PropertyInfo"/> or <see cref="FieldInfo"/>
     /// </summary>
-    private static KeywordBase[] GenerateKeywordsFromMemberInfo(MemberInfo memberInfo)
+    private static KeywordBase[] GenerateKeywordsFromMemberInfo(IMemberInfo memberInfo)
     {
-        IEnumerable<IKeywordGenerator> keywordGeneratorOnType = memberInfo.GetCustomAttributes().OfType<IKeywordGenerator>();
-        return keywordGeneratorOnType.Select(keywordGenerator => keywordGenerator.CreateKeyword(GetMemberType(memberInfo))).ToArray();
-    }
-
-    private static Type GetMemberType(MemberInfo memberInfo)
-    {
-        Debug.Assert((memberInfo.MemberType & (MemberTypes.Property | MemberTypes.Field)) != 0);
-
-        if ((memberInfo.MemberType & MemberTypes.Property) != 0)
-        {
-            Debug.Assert(memberInfo is PropertyInfo);
-            return ((PropertyInfo)memberInfo).PropertyType;
-        }
-
-        Debug.Assert(memberInfo is FieldInfo);
-        return ((FieldInfo)memberInfo).FieldType;
+        IEnumerable<IKeywordGenerator> keywordGeneratorOnType = memberInfo.MemberInfo.GetCustomAttributes().OfType<IKeywordGenerator>();
+        return keywordGeneratorOnType.Select(keywordGenerator => keywordGenerator.CreateKeyword(memberInfo.GetMemberType().Type)).ToArray();
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DateTimeOffsetSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DateTimeOffsetSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
 ﻿using LateApexEarlySpeed.Json.Schema.FluentGenerator.ExtendedKeywords;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
@@ -11,7 +12,7 @@ internal class DateTimeOffsetSchemaGenerationCandidate : ISchemaGenerationCandid
         return typeToConvert == typeof(DateTimeOffset);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         var typeKeyword = new TypeKeyword(InstanceType.String);
         var dateTimeOffsetFormatExtensionKeyword = new DateTimeOffsetFormatExtensionKeyword();

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DateTimeSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DateTimeSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
 ﻿using LateApexEarlySpeed.Json.Schema.FluentGenerator.ExtendedKeywords;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
@@ -11,7 +12,7 @@ internal class DateTimeSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(DateTime);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         var typeKeyword = new TypeKeyword(InstanceType.String);
         var dateTimeFormatExtensionKeyword = new DateTimeFormatExtensionKeyword();

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DecimalSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DecimalSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class DecimalSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(decimal);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForDecimal(keywordsFromProperty);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DoubleSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/DoubleSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class DoubleSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(double);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForDouble(keywordsFromProperty, double.MinValue, double.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/EnumSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/EnumSchemaGenerationCandidate.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Text.Json.Serialization;
 using LateApexEarlySpeed.Json.Schema.Common;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 using LateApexEarlySpeed.Json.Schema.JInstance;
 using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
@@ -14,18 +15,18 @@ internal class EnumSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert.IsEnum;
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
-        IEnumerable<JsonInstanceElement> allowedStringEnums = typeToConvert.GetEnumNames().Select(name => JsonInstanceSerializer.SerializeToElement(name));
+        IEnumerable<JsonInstanceElement> allowedStringEnums = typeToConvert.Type.GetEnumNames().Select(name => JsonInstanceSerializer.SerializeToElement(name));
 
         IEnumerable<JsonInstanceElement> enumCollection;
-        if (HasJsonStringEnumConverter(typeToConvert))
+        if (HasJsonStringEnumConverter(typeToConvert.Type))
         {
             enumCollection = allowedStringEnums;
         }
         else
         {
-            IEnumerable<JsonInstanceElement> allowedNumberEnums = typeToConvert.GetEnumValues().Select(JsonInstanceSerializer.SerializeToElement);
+            IEnumerable<JsonInstanceElement> allowedNumberEnums = typeToConvert.Type.GetEnumValues().Select(JsonInstanceSerializer.SerializeToElement);
             enumCollection = allowedStringEnums.Concat(allowedNumberEnums);
         }
         
@@ -33,7 +34,7 @@ internal class EnumSchemaGenerationCandidate : ISchemaGenerationCandidate
 
         var keywords = new List<KeywordBase> { enumKeyword };
         keywords.AddRange(keywordsFromProperty);
-        keywords.AddRange(SchemaGenerationHelper.GenerateKeywordsFromType(typeToConvert));
+        keywords.AddRange(SchemaGenerationHelper.GenerateKeywordsFromType(typeToConvert.Type));
 
         return new BodyJsonSchema(keywords);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/FloatSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/FloatSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class FloatSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(float);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForDouble(keywordsFromProperty, float.MinValue, float.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/GuidSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/GuidSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class GuidSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(Guid);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         var typeKeyword = new TypeKeyword(InstanceType.String);
         var formatKeyword = new FormatKeyword(GuidFormatValidator.FormatName);

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ISchemaGenerator.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/ISchemaGenerator.cs
@@ -1,9 +1,10 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
 internal interface ISchemaGenerator
 {
-    BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options);
+    BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options);
 }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int16SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int16SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class Int16SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(short);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForSignedInteger(keywordsFromProperty, short.MinValue, short.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int32SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int32SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class Int32SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(int);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForSignedInteger(keywordsFromProperty, int.MinValue, int.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int64SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/Int64SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class Int64SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(long);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForSignedInteger(keywordsFromProperty, long.MinValue, long.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/JsonArraySchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/JsonArraySchemaGenerationCandidate.cs
@@ -1,6 +1,7 @@
 ﻿using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 using System.Text.Json.Nodes;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
@@ -11,7 +12,7 @@ internal class JsonArraySchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(JsonArray);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForJsonType(InstanceType.Array, keywordsFromProperty);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/JsonObjectSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/JsonObjectSchemaGenerationCandidate.cs
@@ -1,6 +1,7 @@
 ﻿using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 using System.Text.Json.Nodes;
+using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
 
@@ -11,7 +12,7 @@ internal class JsonObjectSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(JsonObject);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForJsonType(InstanceType.Object, keywordsFromProperty);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/SByteSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/SByteSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class SByteSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(sbyte);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForSignedInteger(keywordsFromProperty, sbyte.MinValue, sbyte.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/StringDictionarySchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/StringDictionarySchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,18 +11,18 @@ internal class StringDictionarySchemaGenerationCandidate : ISchemaGenerationCand
         return typeToConvert.IsConstructedGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Dictionary<,>) && typeToConvert.GetGenericArguments()[0] == typeof(string);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         var typeKeyword = new TypeKeyword(InstanceType.Object, InstanceType.Null);
-        Type valueType = typeToConvert.GetGenericArguments()[1];
+        IType valueType = typeToConvert.GenericTypeArguments[1];
         JsonSchema valueSchema = JsonSchemaGenerator.GenerateSchema(valueType, Enumerable.Empty<KeywordBase>(), options);
 
         JsonSchema propertySchema;
         if (valueSchema is JsonSchemaResource valueSchemaResource)
         {
-            options.SchemaDefinitions.AddSchemaDefinition(valueType, valueSchemaResource);
+            options.SchemaDefinitions.AddSchemaDefinition(valueType.Type, valueSchemaResource);
 
-            propertySchema = SchemaGenerationHelper.GenerateSchemaReference(valueType, Enumerable.Empty<KeywordBase>(), options.MainDocumentBaseUri!);
+            propertySchema = SchemaGenerationHelper.GenerateSchemaReference(valueType.Type, Enumerable.Empty<KeywordBase>(), options.MainDocumentBaseUri!);
         }
         else
         {

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/StringSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/StringSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class StringSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(string);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return new BodyJsonSchema(keywordsFromProperty.Append(new TypeKeyword(InstanceType.String, InstanceType.Null)));
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt16SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt16SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class UInt16SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(ushort);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForUnsignedInteger(keywordsFromProperty, ushort.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt32SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt32SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class UInt32SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(uint);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForUnsignedInteger(keywordsFromProperty, uint.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt64SchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UInt64SchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class UInt64SchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(ulong);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         return SchemaGenerationHelper.GenerateSchemaForUnsignedInteger(keywordsFromProperty, ulong.MaxValue);
     }

--- a/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UriSchemaGenerationCandidate.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/SchemaGenerators/UriSchemaGenerationCandidate.cs
@@ -1,4 +1,5 @@
-﻿using LateApexEarlySpeed.Json.Schema.JSchema;
+﻿using LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+using LateApexEarlySpeed.Json.Schema.JSchema;
 using LateApexEarlySpeed.Json.Schema.Keywords;
 
 namespace LateApexEarlySpeed.Json.Schema.Generator.SchemaGenerators;
@@ -10,7 +11,7 @@ internal class UriSchemaGenerationCandidate : ISchemaGenerationCandidate
         return typeToConvert == typeof(Uri);
     }
 
-    public BodyJsonSchema Generate(Type typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
+    public BodyJsonSchema Generate(IType typeToConvert, IEnumerable<KeywordBase> keywordsFromProperty, JsonSchemaGeneratorOptions options)
     {
         var typeKeyword = new TypeKeyword(InstanceType.String, InstanceType.Null);
         var formatKeyword = new FormatKeyword(UriReferenceFormatValidator.FormatName);

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/FieldInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/FieldInfoWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class FieldInfoWrapper : IFieldInfo
+{
+    private readonly FieldInfo _fieldInfo;
+
+    public FieldInfoWrapper(FieldInfo fieldInfo)
+    {
+        _fieldInfo = fieldInfo;
+    }
+
+    public MemberInfo MemberInfo => _fieldInfo;
+    public IType FieldType => new TypeWrapper(_fieldInfo.FieldType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IFieldInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IFieldInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal interface IFieldInfo : IMemberInfo
+{
+    IType FieldType { get; }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IMemberInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IMemberInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+public interface IMemberInfo
+{
+    MemberInfo MemberInfo { get; }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IMethodInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IMethodInfo.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal interface IMethodInfo : IMemberInfo
+{
+    MethodInfo MethodInfo { get; }
+    IParameterInfo ReturnParameter { get; }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IParameterInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IParameterInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal interface IParameterInfo
+{
+    IType ParameterType { get; }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IPropertyInfo.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IPropertyInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal interface IPropertyInfo : IMemberInfo
+{
+    IType PropertyType { get; }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IType.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/IType.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal interface IType
+{
+    Type Type { get; }
+
+    IType[] GenericTypeArguments { get; }
+    IType GetArrayElementType();
+
+    IPropertyInfo[] GetProperties(BindingFlags bindingAttr);
+    IFieldInfo[] GetFields(BindingFlags bindingAttr);
+    IMethodInfo[] GetMethods(BindingFlags bindingAttr);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/MemberInfoExtensions.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/MemberInfoExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal static class MemberInfoExtensions
+{
+    public static IType GetMemberType(this IMemberInfo memberInfo)
+    {
+        MemberTypes memberType = memberInfo.MemberInfo.MemberType;
+        Debug.Assert(memberType == MemberTypes.Property || memberType == MemberTypes.Field);
+
+        return memberType == MemberTypes.Property
+            ? ((IPropertyInfo)memberInfo).PropertyType
+            : ((IFieldInfo)memberInfo).FieldType;
+    }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/MethodInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/MethodInfoWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class MethodInfoWrapper : IMethodInfo
+{
+    public MethodInfoWrapper(MethodInfo methodInfo)
+    {
+        MethodInfo = methodInfo;
+    }
+
+    public MemberInfo MemberInfo => MethodInfo;
+    public MethodInfo MethodInfo { get; }
+    public IParameterInfo ReturnParameter => new ParameterInfoWrapper(MethodInfo.ReturnParameter!);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityFieldInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityFieldInfoWrapper.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class NullabilityFieldInfoWrapper : IFieldInfo
+{
+    private readonly NullabilityFieldInfo _field;
+
+    public NullabilityFieldInfoWrapper(NullabilityFieldInfo field)
+    {
+        _field = field;
+    }
+
+    public MemberInfo MemberInfo => _field;
+    public IType FieldType => new NullabilityTypeWrapper(_field.NullabilityFieldType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityMethodInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityMethodInfoWrapper.cs
@@ -12,7 +12,7 @@ internal class NullabilityMethodInfoWrapper : IMethodInfo
         _method = method;
     }
 
-    public MemberInfo MemberInfo => _method;
-    public MethodInfo MethodInfo => _method;
+    public MemberInfo MemberInfo => _method.MethodInfo;
+    public MethodInfo MethodInfo => _method.MethodInfo;
     public IParameterInfo ReturnParameter => new NullabilityParameterInfoWrapper(_method.NullabilityReturnParameter);
 }

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityMethodInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityMethodInfoWrapper.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class NullabilityMethodInfoWrapper : IMethodInfo
+{
+    private readonly NullabilityMethodInfo _method;
+
+    public NullabilityMethodInfoWrapper(NullabilityMethodInfo method)
+    {
+        _method = method;
+    }
+
+    public MemberInfo MemberInfo => _method;
+    public MethodInfo MethodInfo => _method;
+    public IParameterInfo ReturnParameter => new NullabilityParameterInfoWrapper(_method.NullabilityReturnParameter);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityParameterInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityParameterInfoWrapper.cs
@@ -1,0 +1,15 @@
+﻿using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class NullabilityParameterInfoWrapper : IParameterInfo
+{
+    private readonly NullabilityParameterInfo _parameter;
+
+    public NullabilityParameterInfoWrapper(NullabilityParameterInfo parameter)
+    {
+        _parameter = parameter;
+    }
+
+    public IType ParameterType => new NullabilityTypeWrapper(_parameter.NullabilityParameterType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityPropertyInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityPropertyInfoWrapper.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class NullabilityPropertyInfoWrapper : IPropertyInfo
+{
+    private readonly NullabilityPropertyInfo _propertyInfo;
+
+    public NullabilityPropertyInfoWrapper(NullabilityPropertyInfo propertyInfo)
+    {
+        _propertyInfo = propertyInfo;
+    }
+
+    public MemberInfo MemberInfo => _propertyInfo;
+    public IType PropertyType => new NullabilityTypeWrapper(_propertyInfo.NullabilityPropertyType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityTypeWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/NullabilityTypeWrapper.cs
@@ -1,0 +1,49 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using LateApexEarlySpeed.Nullability.Generic;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class NullabilityTypeWrapper : IType
+{
+    private readonly NullabilityType _nullabilityType;
+
+    public NullabilityTypeWrapper(NullabilityType nullabilityType)
+    {
+        _nullabilityType = nullabilityType;
+    }
+
+    public NullabilityState NullabilityState => _nullabilityType.NullabilityState;
+
+    public Type Type => _nullabilityType.Type;
+
+    public IType[] GenericTypeArguments => _nullabilityType.GenericTypeArguments.Select(arg => new NullabilityTypeWrapper(arg)).ToArray<IType>();
+
+    public IType GetArrayElementType()
+    {
+        if (!Type.IsArray || !Type.HasElementType)
+        {
+            throw new InvalidOperationException($"Current type: {Type.FullName} is not an array type with element");
+        }
+
+        NullabilityType? elementType = _nullabilityType.GetArrayElementType();
+        Debug.Assert(elementType is not null);
+
+        return new NullabilityTypeWrapper(elementType);
+    }
+
+    public IPropertyInfo[] GetProperties(BindingFlags bindingAttr)
+    {
+        return _nullabilityType.GetProperties(bindingAttr).Select(prop => new NullabilityPropertyInfoWrapper(prop)).ToArray<IPropertyInfo>();
+    }
+
+    public IFieldInfo[] GetFields(BindingFlags bindingAttr)
+    {
+        return _nullabilityType.GetFields(bindingAttr).Select(field => new NullabilityFieldInfoWrapper(field)).ToArray<IFieldInfo>();
+    }
+
+    public IMethodInfo[] GetMethods(BindingFlags bindingAttr)
+    {
+        return _nullabilityType.GetMethods(bindingAttr).Select(method => new NullabilityMethodInfoWrapper(method)).ToArray<IMethodInfo>();
+    }
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/ParameterInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/ParameterInfoWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class ParameterInfoWrapper : IParameterInfo
+{
+    private readonly ParameterInfo _parameterInfo;
+
+    public ParameterInfoWrapper(ParameterInfo parameterInfo)
+    {
+        _parameterInfo = parameterInfo;
+    }
+
+    public IType ParameterType => new TypeWrapper(_parameterInfo.ParameterType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/PropertyInfoWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/PropertyInfoWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class PropertyInfoWrapper : IPropertyInfo
+{
+    private readonly PropertyInfo _propertyInfo;
+
+    public PropertyInfoWrapper(PropertyInfo propertyInfo)
+    {
+        _propertyInfo = propertyInfo;
+    }
+
+    public MemberInfo MemberInfo => _propertyInfo;
+    public IType PropertyType => new TypeWrapper(_propertyInfo.PropertyType);
+}

--- a/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/TypeWrapper.cs
+++ b/LateApexEarlySpeed.Json.Schema/Generator/TypeAbstraction/TypeWrapper.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+
+namespace LateApexEarlySpeed.Json.Schema.Generator.TypeAbstraction;
+
+internal class TypeWrapper : IType
+{
+    public TypeWrapper(Type type)
+    {
+        Type = type;
+    }
+
+    public Type Type { get; }
+    public IType[] GenericTypeArguments => Type.GenericTypeArguments.Select(arg => new TypeWrapper(arg)).ToArray<IType>();
+    public IType GetArrayElementType()
+    {
+        if (!Type.IsArray || !Type.HasElementType)
+        {
+            throw new InvalidOperationException($"Current type: {Type.FullName} is not an array type with element");
+        }
+
+        return new TypeWrapper(Type.GetElementType()!);
+    }
+
+    public IPropertyInfo[] GetProperties(BindingFlags bindingAttr)
+    {
+        PropertyInfo[] propertyInfos = Type.GetProperties(bindingAttr);
+
+        return propertyInfos.Select(prop => new PropertyInfoWrapper(prop)).ToArray<IPropertyInfo>();
+    }
+
+    public IFieldInfo[] GetFields(BindingFlags bindingAttr)
+    {
+        FieldInfo[] fields = Type.GetFields(bindingAttr);
+
+        return fields.Select(f => new FieldInfoWrapper(f)).ToArray<IFieldInfo>();
+    }
+
+    public IMethodInfo[] GetMethods(BindingFlags bindingAttr)
+    {
+        MethodInfo[] methodInfos = Type.GetMethods(bindingAttr);
+
+        return methodInfos.Select(m => new MethodInfoWrapper(m)).ToArray<IMethodInfo>();
+    }
+}

--- a/LateApexEarlySpeed.Json.Schema/LateApexEarlySpeed.Json.Schema.csproj
+++ b/LateApexEarlySpeed.Json.Schema/LateApexEarlySpeed.Json.Schema.csproj
@@ -41,9 +41,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LateApexEarlySpeed.Nullability.Generic" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LateApexEarlySpeed.Nullability.Generic\LateApexEarlySpeed.Nullability.Generic.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LateApexEarlySpeed.Json.Schema/LateApexEarlySpeed.Json.Schema.csproj
+++ b/LateApexEarlySpeed.Json.Schema/LateApexEarlySpeed.Json.Schema.csproj
@@ -41,6 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LateApexEarlySpeed.Nullability.Generic" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>

--- a/LateApexEarlySpeed.Nullability.Generic/NullabilityFieldInfo.cs
+++ b/LateApexEarlySpeed.Nullability.Generic/NullabilityFieldInfo.cs
@@ -9,14 +9,18 @@ namespace LateApexEarlySpeed.Nullability.Generic;
 /// </summary>
 public partial class NullabilityFieldInfo
 {
-    private readonly FieldInfo _fieldInfo;
     private readonly NullabilityType _reflectedType;
 
     private volatile NullabilityType? _nullabilityFieldType;
 
+    /// <summary>
+    /// Get the actual runtime FieldInfo
+    /// </summary>
+    public FieldInfo FieldInfo { get; }
+
     protected internal NullabilityFieldInfo(FieldInfo fieldInfo, NullabilityType reflectedType)
     {
-        _fieldInfo = fieldInfo;
+        FieldInfo = fieldInfo;
         _reflectedType = reflectedType;
     }
 
@@ -36,7 +40,7 @@ public partial class NullabilityFieldInfo
             {
                 NullabilityElement nullabilityElement = GetFieldNullabilityInfo();
 
-                _nullabilityFieldType = new NullabilityType(_fieldInfo.FieldType, nullabilityElement);
+                _nullabilityFieldType = new NullabilityType(FieldInfo.FieldType, nullabilityElement);
             }
 
             return _nullabilityFieldType;
@@ -45,9 +49,9 @@ public partial class NullabilityFieldInfo
 
     private NullabilityElement GetFieldNullabilityInfo()
     {
-        NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(_fieldInfo.DeclaringType!);
+        NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(FieldInfo.DeclaringType!);
 
-        FieldInfo fieldInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(_fieldInfo);
+        FieldInfo fieldInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(FieldInfo);
 
         NullabilityElement fieldRawNullabilityInfo = RawNullabilityAnnotationConverter.ReadField(fieldInfoInDeclaringGenericDefType);
 
@@ -60,96 +64,96 @@ public partial class NullabilityFieldInfo : FieldInfo
     public override bool Equals(object? obj)
     {
         return obj is NullabilityFieldInfo nullabilityFieldInfo 
-               && _fieldInfo.Equals(nullabilityFieldInfo._fieldInfo) 
+               && FieldInfo.Equals(nullabilityFieldInfo.FieldInfo) 
                && _reflectedType.Equals(nullabilityFieldInfo._reflectedType);
     }
 
     public override int GetHashCode()
     {
-        return _fieldInfo.GetHashCode();
+        return FieldInfo.GetHashCode();
     }
 
     public override Type[] GetOptionalCustomModifiers()
     {
-        return _fieldInfo.GetOptionalCustomModifiers();
+        return FieldInfo.GetOptionalCustomModifiers();
     }
 
     public override object GetRawConstantValue()
     {
-        return _fieldInfo.GetRawConstantValue();
+        return FieldInfo.GetRawConstantValue();
     }
 
     public override Type[] GetRequiredCustomModifiers()
     {
-        return _fieldInfo.GetRequiredCustomModifiers();
+        return FieldInfo.GetRequiredCustomModifiers();
     }
 
     public override object? GetValueDirect(TypedReference obj)
     {
-        return _fieldInfo.GetValueDirect(obj);
+        return FieldInfo.GetValueDirect(obj);
     }
 
     public override void SetValueDirect(TypedReference obj, object value)
     {
-        _fieldInfo.SetValueDirect(obj, value);
+        FieldInfo.SetValueDirect(obj, value);
     }
 
-    public override bool IsSecurityCritical => _fieldInfo.IsSecurityCritical;
-    public override bool IsSecuritySafeCritical => _fieldInfo.IsSecuritySafeCritical;
-    public override bool IsSecurityTransparent => _fieldInfo.IsSecurityTransparent;
-    public override MemberTypes MemberType => _fieldInfo.MemberType;
+    public override bool IsSecurityCritical => FieldInfo.IsSecurityCritical;
+    public override bool IsSecuritySafeCritical => FieldInfo.IsSecuritySafeCritical;
+    public override bool IsSecurityTransparent => FieldInfo.IsSecurityTransparent;
+    public override MemberTypes MemberType => FieldInfo.MemberType;
     public override IList<CustomAttributeData> GetCustomAttributesData()
     {
-        return _fieldInfo.GetCustomAttributesData();
+        return FieldInfo.GetCustomAttributesData();
     }
 
     public override bool HasSameMetadataDefinitionAs(MemberInfo other)
     {
-        return _fieldInfo.HasSameMetadataDefinitionAs(other);
+        return FieldInfo.HasSameMetadataDefinitionAs(other);
     }
 
-    public override IEnumerable<CustomAttributeData> CustomAttributes => _fieldInfo.CustomAttributes;
-    public override int MetadataToken => _fieldInfo.MetadataToken;
-    public override Module Module => _fieldInfo.Module;
+    public override IEnumerable<CustomAttributeData> CustomAttributes => FieldInfo.CustomAttributes;
+    public override int MetadataToken => FieldInfo.MetadataToken;
+    public override Module Module => FieldInfo.Module;
     public override string? ToString()
     {
-        return _fieldInfo.ToString();
+        return FieldInfo.ToString();
     }
 
     public override object[] GetCustomAttributes(bool inherit)
     {
-        return _fieldInfo.GetCustomAttributes(inherit);
+        return FieldInfo.GetCustomAttributes(inherit);
     }
 
     public override object[] GetCustomAttributes(Type attributeType, bool inherit)
     {
-        return _fieldInfo.GetCustomAttributes(attributeType, inherit);
+        return FieldInfo.GetCustomAttributes(attributeType, inherit);
     }
 
     public override bool IsDefined(Type attributeType, bool inherit)
     {
-        return _fieldInfo.IsDefined(attributeType, inherit);
+        return FieldInfo.IsDefined(attributeType, inherit);
     }
 
-    public override Type? DeclaringType => _fieldInfo.DeclaringType;
+    public override Type? DeclaringType => FieldInfo.DeclaringType;
 
-    public override string Name => _fieldInfo.Name;
+    public override string Name => FieldInfo.Name;
 
-    public override Type? ReflectedType => _fieldInfo.ReflectedType;
+    public override Type? ReflectedType => FieldInfo.ReflectedType;
 
     public override object? GetValue(object? obj)
     {
-        return _fieldInfo.GetValue(obj);
+        return FieldInfo.GetValue(obj);
     }
 
     public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder? binder, CultureInfo culture)
     {
-        _fieldInfo.SetValue(obj, value, invokeAttr, binder, culture);
+        FieldInfo.SetValue(obj, value, invokeAttr, binder, culture);
     }
 
-    public override FieldAttributes Attributes => _fieldInfo.Attributes;
+    public override FieldAttributes Attributes => FieldInfo.Attributes;
 
-    public override RuntimeFieldHandle FieldHandle => _fieldInfo.FieldHandle;
+    public override RuntimeFieldHandle FieldHandle => FieldInfo.FieldHandle;
 
-    public override Type FieldType => _fieldInfo.FieldType;
+    public override Type FieldType => FieldInfo.FieldType;
 }

--- a/LateApexEarlySpeed.Nullability.Generic/NullabilityMethodInfo.cs
+++ b/LateApexEarlySpeed.Nullability.Generic/NullabilityMethodInfo.cs
@@ -8,15 +8,19 @@ namespace LateApexEarlySpeed.Nullability.Generic;
 /// </summary>
 public partial class NullabilityMethodInfo
 {
-    private readonly MethodInfo _methodInfo;
-    private readonly NullabilityType _reflectedType;
-
     private volatile NullabilityParameterInfo? _nullabilityReturnParameter;
     private volatile NullabilityParameterInfo[]? _nullabilityParameters;
 
+    private readonly NullabilityType _reflectedType;
+
+    /// <summary>
+    /// Get the actual runtime MethodInfo
+    /// </summary>
+    public MethodInfo MethodInfo { get; }
+
     protected internal NullabilityMethodInfo(MethodInfo method, NullabilityType reflectedType)
     {
-        _methodInfo = method;
+        MethodInfo = method;
         _reflectedType = reflectedType;
     }
 
@@ -29,11 +33,11 @@ public partial class NullabilityMethodInfo
         {
             if (_nullabilityReturnParameter is null)
             {
-                NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(_methodInfo.DeclaringType!);
+                NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(MethodInfo.DeclaringType!);
 
-                MethodInfo methodInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(_methodInfo);
+                MethodInfo methodInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(MethodInfo);
 
-                _nullabilityReturnParameter = new(_methodInfo.ReturnParameter, methodInfoInDeclaringGenericDefType.ReturnParameter, baseClassType);
+                _nullabilityReturnParameter = new(MethodInfo.ReturnParameter, methodInfoInDeclaringGenericDefType.ReturnParameter, baseClassType);
             }
 
             return _nullabilityReturnParameter;
@@ -48,11 +52,11 @@ public partial class NullabilityMethodInfo
     {
         if (_nullabilityParameters is null)
         {
-            NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(_methodInfo.DeclaringType!);
+            NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(MethodInfo.DeclaringType!);
 
-            MethodInfo methodInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(_methodInfo);
+            MethodInfo methodInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(MethodInfo);
 
-            ParameterInfo[] parameters = _methodInfo.GetParameters();
+            ParameterInfo[] parameters = MethodInfo.GetParameters();
             ParameterInfo[] parametersInGenericDefType = methodInfoInDeclaringGenericDefType.GetParameters();
 
             _nullabilityParameters = parameters.Select((p, idx) => new NullabilityParameterInfo(p, parametersInGenericDefType[idx], baseClassType)).ToArray();
@@ -66,123 +70,123 @@ public partial class NullabilityMethodInfo : MethodInfo
 {
     public override Delegate CreateDelegate(Type delegateType)
     {
-        return _methodInfo.CreateDelegate(delegateType);
+        return MethodInfo.CreateDelegate(delegateType);
     }
 
     public override Delegate CreateDelegate(Type delegateType, object? target)
     {
-        return _methodInfo.CreateDelegate(delegateType, target);
+        return MethodInfo.CreateDelegate(delegateType, target);
     }
 
     public override bool Equals(object? obj)
     {
         return obj is NullabilityMethodInfo nullabilityMethodInfo 
-               && _methodInfo.Equals(nullabilityMethodInfo._methodInfo)
+               && MethodInfo.Equals(nullabilityMethodInfo.MethodInfo)
                && _reflectedType.Equals(nullabilityMethodInfo._reflectedType);
     }
 
     public override Type[] GetGenericArguments()
     {
-        return _methodInfo.GetGenericArguments();
+        return MethodInfo.GetGenericArguments();
     }
 
     public override MethodInfo GetGenericMethodDefinition()
     {
-        return _methodInfo.GetGenericMethodDefinition();
+        return MethodInfo.GetGenericMethodDefinition();
     }
 
     public override int GetHashCode()
     {
-        return _methodInfo.GetHashCode();
+        return MethodInfo.GetHashCode();
     }
 
     public override MethodInfo MakeGenericMethod(params Type[] typeArguments)
     {
-        return _methodInfo.MakeGenericMethod(typeArguments);
+        return MethodInfo.MakeGenericMethod(typeArguments);
     }
 
-    public override MemberTypes MemberType => _methodInfo.MemberType;
-    public override ParameterInfo ReturnParameter => _methodInfo.ReturnParameter;
-    public override Type ReturnType => _methodInfo.ReturnType;
+    public override MemberTypes MemberType => MethodInfo.MemberType;
+    public override ParameterInfo ReturnParameter => MethodInfo.ReturnParameter;
+    public override Type ReturnType => MethodInfo.ReturnType;
 
     public override MethodBody? GetMethodBody()
     {
-        return _methodInfo.GetMethodBody();
+        return MethodInfo.GetMethodBody();
     }
 
     public override ParameterInfo[] GetParameters()
     {
-        return _methodInfo.GetParameters();
+        return MethodInfo.GetParameters();
     }
 
-    public override CallingConventions CallingConvention => _methodInfo.CallingConvention;
-    public override bool ContainsGenericParameters => _methodInfo.ContainsGenericParameters;
-    public override bool IsConstructedGenericMethod => _methodInfo.IsConstructedGenericMethod;
-    public override bool IsGenericMethod => _methodInfo.IsGenericMethod;
-    public override bool IsGenericMethodDefinition => _methodInfo.IsGenericMethodDefinition;
-    public override bool IsSecurityCritical => _methodInfo.IsSecurityCritical;
-    public override bool IsSecuritySafeCritical => _methodInfo.IsSecuritySafeCritical;
-    public override bool IsSecurityTransparent => _methodInfo.IsSecurityTransparent;
-    public override MethodImplAttributes MethodImplementationFlags => _methodInfo.MethodImplementationFlags;
+    public override CallingConventions CallingConvention => MethodInfo.CallingConvention;
+    public override bool ContainsGenericParameters => MethodInfo.ContainsGenericParameters;
+    public override bool IsConstructedGenericMethod => MethodInfo.IsConstructedGenericMethod;
+    public override bool IsGenericMethod => MethodInfo.IsGenericMethod;
+    public override bool IsGenericMethodDefinition => MethodInfo.IsGenericMethodDefinition;
+    public override bool IsSecurityCritical => MethodInfo.IsSecurityCritical;
+    public override bool IsSecuritySafeCritical => MethodInfo.IsSecuritySafeCritical;
+    public override bool IsSecurityTransparent => MethodInfo.IsSecurityTransparent;
+    public override MethodImplAttributes MethodImplementationFlags => MethodInfo.MethodImplementationFlags;
 
     public override IList<CustomAttributeData> GetCustomAttributesData()
     {
-        return _methodInfo.GetCustomAttributesData();
+        return MethodInfo.GetCustomAttributesData();
     }
 
     public override bool HasSameMetadataDefinitionAs(MemberInfo other)
     {
-        return _methodInfo.HasSameMetadataDefinitionAs(other);
+        return MethodInfo.HasSameMetadataDefinitionAs(other);
     }
 
-    public override IEnumerable<CustomAttributeData> CustomAttributes => _methodInfo.CustomAttributes;
-    public override int MetadataToken => _methodInfo.MetadataToken;
-    public override Module Module => _methodInfo.Module;
+    public override IEnumerable<CustomAttributeData> CustomAttributes => MethodInfo.CustomAttributes;
+    public override int MetadataToken => MethodInfo.MetadataToken;
+    public override Module Module => MethodInfo.Module;
 
     public override string? ToString()
     {
-        return _methodInfo.ToString();
+        return MethodInfo.ToString();
     }
 
     public override object[] GetCustomAttributes(bool inherit)
     {
-        return _methodInfo.GetCustomAttributes(inherit);
+        return MethodInfo.GetCustomAttributes(inherit);
     }
 
     public override object[] GetCustomAttributes(Type attributeType, bool inherit)
     {
-        return _methodInfo.GetCustomAttributes(attributeType, inherit);
+        return MethodInfo.GetCustomAttributes(attributeType, inherit);
     }
 
     public override bool IsDefined(Type attributeType, bool inherit)
     {
-        return _methodInfo.IsDefined(attributeType, inherit);
+        return MethodInfo.IsDefined(attributeType, inherit);
     }
 
-    public override Type? DeclaringType => _methodInfo.DeclaringType;
+    public override Type? DeclaringType => MethodInfo.DeclaringType;
 
-    public override string Name => _methodInfo.Name;
+    public override string Name => MethodInfo.Name;
 
-    public override Type? ReflectedType => _methodInfo.ReflectedType;
+    public override Type? ReflectedType => MethodInfo.ReflectedType;
 
     public override MethodImplAttributes GetMethodImplementationFlags()
     {
-        return _methodInfo.GetMethodImplementationFlags();
+        return MethodInfo.GetMethodImplementationFlags();
     }
 
     public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo culture)
     {
-        return _methodInfo.Invoke(obj, invokeAttr, binder, parameters, culture);
+        return MethodInfo.Invoke(obj, invokeAttr, binder, parameters, culture);
     }
 
-    public override MethodAttributes Attributes => _methodInfo.Attributes;
+    public override MethodAttributes Attributes => MethodInfo.Attributes;
 
-    public override RuntimeMethodHandle MethodHandle => _methodInfo.MethodHandle;
+    public override RuntimeMethodHandle MethodHandle => MethodInfo.MethodHandle;
 
     public override MethodInfo GetBaseDefinition()
     {
-        return _methodInfo.GetBaseDefinition();
+        return MethodInfo.GetBaseDefinition();
     }
 
-    public override ICustomAttributeProvider ReturnTypeCustomAttributes => _methodInfo.ReturnTypeCustomAttributes;
+    public override ICustomAttributeProvider ReturnTypeCustomAttributes => MethodInfo.ReturnTypeCustomAttributes;
 }

--- a/LateApexEarlySpeed.Nullability.Generic/NullabilityPropertyInfo.cs
+++ b/LateApexEarlySpeed.Nullability.Generic/NullabilityPropertyInfo.cs
@@ -9,14 +9,18 @@ namespace LateApexEarlySpeed.Nullability.Generic;
 /// </summary>
 public partial class NullabilityPropertyInfo
 {
-    private readonly PropertyInfo _propertyInfo;
     private readonly NullabilityType _reflectedType;
 
     private volatile NullabilityType? _nullabilityPropertyType;
 
+    /// <summary>
+    /// Get the actual runtime PropertyInfo
+    /// </summary>
+    public PropertyInfo PropertyInfo { get; }
+
     protected internal NullabilityPropertyInfo(PropertyInfo propertyInfo, NullabilityType reflectedType)
     {
-        _propertyInfo = propertyInfo;
+        PropertyInfo = propertyInfo;
         _reflectedType = reflectedType;
     }
 
@@ -31,7 +35,7 @@ public partial class NullabilityPropertyInfo
             {
                 NullabilityElement nullabilityElement = GetPropertyNullabilityInfo();
 
-                _nullabilityPropertyType = new NullabilityType(_propertyInfo.PropertyType, nullabilityElement);
+                _nullabilityPropertyType = new NullabilityType(PropertyInfo.PropertyType, nullabilityElement);
             }
 
             return _nullabilityPropertyType;
@@ -40,9 +44,9 @@ public partial class NullabilityPropertyInfo
 
     private NullabilityElement GetPropertyNullabilityInfo()
     {
-        NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(_propertyInfo.DeclaringType!);
+        NullabilityType baseClassType = _reflectedType.CreateDeclaringBaseClassType(PropertyInfo.DeclaringType!);
 
-        PropertyInfo propertyInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(_propertyInfo);
+        PropertyInfo propertyInfoInDeclaringGenericDefType = baseClassType.Type.GetMemberInfoInGenericDefType(PropertyInfo);
 
         NullabilityElement propertyRawNullabilityInfo = propertyInfoInDeclaringGenericDefType.GetGetMethod() is null 
             ? RawNullabilityAnnotationConverter.ReadPropertySetter(propertyInfoInDeclaringGenericDefType) 
@@ -59,7 +63,7 @@ public partial class NullabilityPropertyInfo
     {
         get
         {
-            if (_propertyInfo.GetGetMethod() is null)
+            if (PropertyInfo.GetGetMethod() is null)
             {
                 return NullabilityState.Unknown;
             }
@@ -76,7 +80,7 @@ public partial class NullabilityPropertyInfo
     {
         get
         {
-            if (_propertyInfo.GetSetMethod() is null)
+            if (PropertyInfo.GetSetMethod() is null)
             {
                 return NullabilityState.Unknown;
             }
@@ -90,123 +94,123 @@ public partial class NullabilityPropertyInfo : PropertyInfo
 {
     public override object[] GetCustomAttributes(bool inherit)
     {
-        return _propertyInfo.GetCustomAttributes(inherit);
+        return PropertyInfo.GetCustomAttributes(inherit);
     }
 
     public override object[] GetCustomAttributes(Type attributeType, bool inherit)
     {
-        return _propertyInfo.GetCustomAttributes(attributeType, inherit);
+        return PropertyInfo.GetCustomAttributes(attributeType, inherit);
     }
 
     public override bool IsDefined(Type attributeType, bool inherit)
     {
-        return _propertyInfo.IsDefined(attributeType, inherit);
+        return PropertyInfo.IsDefined(attributeType, inherit);
     }
 
-    public override Type? DeclaringType => _propertyInfo.DeclaringType;
+    public override Type? DeclaringType => PropertyInfo.DeclaringType;
 
-    public override string Name => _propertyInfo.Name;
+    public override string Name => PropertyInfo.Name;
 
-    public override Type? ReflectedType => _propertyInfo.ReflectedType;
+    public override Type? ReflectedType => PropertyInfo.ReflectedType;
 
     public override MethodInfo[] GetAccessors(bool nonPublic)
     {
-        return _propertyInfo.GetAccessors(nonPublic);
+        return PropertyInfo.GetAccessors(nonPublic);
     }
 
     public override MethodInfo? GetGetMethod(bool nonPublic)
     {
-        return _propertyInfo.GetGetMethod(nonPublic);
+        return PropertyInfo.GetGetMethod(nonPublic);
     }
 
     public override ParameterInfo[] GetIndexParameters()
     {
-        return _propertyInfo.GetIndexParameters();
+        return PropertyInfo.GetIndexParameters();
     }
 
     public override MethodInfo? GetSetMethod(bool nonPublic)
     {
-        return _propertyInfo.GetSetMethod(nonPublic);
+        return PropertyInfo.GetSetMethod(nonPublic);
     }
 
     public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
     {
-        return _propertyInfo.GetValue(obj, invokeAttr, binder, index, culture);
+        return PropertyInfo.GetValue(obj, invokeAttr, binder, index, culture);
     }
 
     public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo culture)
     {
-        _propertyInfo.SetValue(obj, value, invokeAttr, binder, index, culture);
+        PropertyInfo.SetValue(obj, value, invokeAttr, binder, index, culture);
     }
 
-    public override PropertyAttributes Attributes => _propertyInfo.Attributes;
+    public override PropertyAttributes Attributes => PropertyInfo.Attributes;
 
-    public override bool CanRead => _propertyInfo.CanRead;
+    public override bool CanRead => PropertyInfo.CanRead;
 
-    public override bool CanWrite => _propertyInfo.CanWrite;
+    public override bool CanWrite => PropertyInfo.CanWrite;
 
-    public override Type PropertyType => _propertyInfo.PropertyType;
+    public override Type PropertyType => PropertyInfo.PropertyType;
 
     public override bool Equals(object? obj)
     {
         return obj is NullabilityPropertyInfo nullabilityPropertyInfo
-        && _propertyInfo.Equals(nullabilityPropertyInfo._propertyInfo)
+        && PropertyInfo.Equals(nullabilityPropertyInfo.PropertyInfo)
         && _reflectedType.Equals(nullabilityPropertyInfo._reflectedType);
     }
 
     public override object? GetConstantValue()
     {
-        return _propertyInfo.GetConstantValue();
+        return PropertyInfo.GetConstantValue();
     }
 
     public override int GetHashCode()
     {
-        return _propertyInfo.GetHashCode();
+        return PropertyInfo.GetHashCode();
     }
 
     public override Type[] GetOptionalCustomModifiers()
     {
-        return _propertyInfo.GetOptionalCustomModifiers();
+        return PropertyInfo.GetOptionalCustomModifiers();
     }
 
     public override object? GetRawConstantValue()
     {
-        return _propertyInfo.GetRawConstantValue();
+        return PropertyInfo.GetRawConstantValue();
     }
 
     public override Type[] GetRequiredCustomModifiers()
     {
-        return _propertyInfo.GetRequiredCustomModifiers();
+        return PropertyInfo.GetRequiredCustomModifiers();
     }
 
     public override object? GetValue(object? obj, object?[]? index)
     {
-        return _propertyInfo.GetValue(obj, index);
+        return PropertyInfo.GetValue(obj, index);
     }
 
     public override void SetValue(object? obj, object? value, object?[]? index)
     {
-        _propertyInfo.SetValue(obj, value, index);
+        PropertyInfo.SetValue(obj, value, index);
     }
 
-    public override MethodInfo? GetMethod => _propertyInfo.GetMethod;
-    public override MemberTypes MemberType => _propertyInfo.MemberType;
-    public override MethodInfo? SetMethod => _propertyInfo.SetMethod;
+    public override MethodInfo? GetMethod => PropertyInfo.GetMethod;
+    public override MemberTypes MemberType => PropertyInfo.MemberType;
+    public override MethodInfo? SetMethod => PropertyInfo.SetMethod;
     public override IList<CustomAttributeData> GetCustomAttributesData()
     {
-        return _propertyInfo.GetCustomAttributesData();
+        return PropertyInfo.GetCustomAttributesData();
     }
 
     public override bool HasSameMetadataDefinitionAs(MemberInfo other)
     {
-        return _propertyInfo.HasSameMetadataDefinitionAs(other);
+        return PropertyInfo.HasSameMetadataDefinitionAs(other);
     }
 
-    public override IEnumerable<CustomAttributeData> CustomAttributes => _propertyInfo.CustomAttributes;
-    public override int MetadataToken => _propertyInfo.MetadataToken;
-    public override Module Module => _propertyInfo.Module;
+    public override IEnumerable<CustomAttributeData> CustomAttributes => PropertyInfo.CustomAttributes;
+    public override int MetadataToken => PropertyInfo.MetadataToken;
+    public override Module Module => PropertyInfo.Module;
     public override string? ToString()
     {
-        return _propertyInfo.ToString();
+        return PropertyInfo.ToString();
     }
 }

--- a/LateApexEarlySpeed.Nullability.Generic/TypeExtensions.cs
+++ b/LateApexEarlySpeed.Nullability.Generic/TypeExtensions.cs
@@ -6,7 +6,7 @@ internal static class TypeExtensions
 {
     public static Type[] GenericTypeArgumentsOrParameters(this Type type)
     {
-        return type.IsGenericTypeDefinition ? type.GetTypeInfo().GenericTypeParameters : type.GenericTypeArguments;
+        return type.GetGenericArguments();
     }
 
     public static Type GetGenericTypeDefinitionIfIsGenericType(this Type type)


### PR DESCRIPTION
Fix #55 

JSON schema library now is able to get nullability info of properties (fields) by .net nullability annotation, so that library users can define their types with c# nullability annotation naturally without additional attributes.
The well known technical pain point of generic type nullability info is overcome by implementing LateApexEarlySpeed.Nullability.Generic.