### PR TITLE
Allow uppercase letters in email validation regex

### DIFF
--- a/LateApexEarlySpeed.Json.Schema.UnitTests/JsonSchemaGeneratorTest.cs
+++ b/LateApexEarlySpeed.Json.Schema.UnitTests/JsonSchemaGeneratorTest.cs
@@ -1746,6 +1746,13 @@ public class JsonSchemaGeneratorTest
         yield return TestSample.Create<EmailAttributeTestClass>(
             """
 {
+  "Email": "HELLO@WORLD.COM"
+}
+""", ValidationResult.ValidResult);
+
+        yield return TestSample.Create<EmailAttributeTestClass>(
+            """
+{
   "Email": "A text containing a hello@world.com email address."
 } 
 """, CreateSingleErrorResult(

--- a/LateApexEarlySpeed.Json.Schema.UnitTests/TestData/format.json
+++ b/LateApexEarlySpeed.Json.Schema.UnitTests/TestData/format.json
@@ -60,6 +60,11 @@
         "description": "invalid email string - A text containing a hello@world.com email address",
         "data": "A text containing a hello@world.com email address",
         "valid": false
+      },
+      {
+        "description": "caps are allowed in email string",
+        "data": "HELLO.ABC-DE@EMAIL.COM",
+        "valid": true
       }
     ]
   },

--- a/LateApexEarlySpeed.Json.Schema/Keywords/EmailFormatValidator.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/EmailFormatValidator.cs
@@ -13,7 +13,7 @@ internal class EmailFormatValidator : FormatValidator
     /// </summary>
 #pragma warning restore CS1570
     private static readonly LazyCompiledRegex EmailPattern = new(
-        "^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$", RegexFactory.DefaultMatchTimeout);
+        "^(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$", RegexFactory.DefaultMatchTimeout);
 
     public override bool Validate(string content)
     {


### PR DESCRIPTION
Updated the email validation regex to accept uppercase letters (A-Z) in both the local and domain parts of email addresses. Added corresponding test cases in JsonSchemaGeneratorTest.cs and format.json to verify that emails with uppercase characters are considered valid, ensuring compliance with email format standards.