### PR TITLE
Issue 96 generate error messages option

### DIFF
--- a/LateApexEarlySpeed.Json.Schema.UnitTests/JsonValidatorTest.cs
+++ b/LateApexEarlySpeed.Json.Schema.UnitTests/JsonValidatorTest.cs
@@ -54,19 +54,32 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task ValidateByStringSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task ValidateByStringSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
 
             JsonValidator jsonValidator = await CreateJsonValidatorWithExternalDocumentSupportAsync(dialect, schema, testCaseDescription, ignoreResourceIdFromUnknownKeyword);
 
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat}).IsValid);
+            ValidationResult actualValidationResult = jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage});
+            Assert.Equal(expectedValidationResult, actualValidationResult.IsValid);
+
+            Assert.All(actualValidationResult.ValidationErrors, error =>
+            {
+                if (generateErrorMessage)
+                {
+                    Assert.NotEmpty(error.ErrorMessage);
+                }
+                else
+                {
+                    Assert.Empty(error.ErrorMessage);
+                }
+            });
         }
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task GetStandardJsonSchemaText_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task GetStandardJsonSchemaText_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
@@ -80,7 +93,7 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
             // Generate jsonValidator from previous generated json schema text
             jsonValidator = await CreateJsonValidatorWithExternalDocumentSupportAsync(dialect, generatedSchemaText, testCaseDescription, ignoreResourceIdFromUnknownKeyword);
 
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { ValidateFormat = false, OutputFormat = outputFormat}).IsValid);
+            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
         }
 
         private async Task<JsonValidator> CreateJsonValidatorWithExternalDocumentSupportAsync(DialectKind dialect, string schema, string testCaseDescription, bool ignoreResourceIdInUnknownKeyword)
@@ -104,7 +117,7 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task ValidateBySpanSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task ValidateBySpanSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
@@ -123,12 +136,12 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
                 }
             }
 
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat }).IsValid);
+            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
         }
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task ValidateByStreamSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task ValidateByStreamSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
@@ -154,14 +167,14 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
 
                 await using (var utf8JsonInstance = new MemoryStream(Encoding.UTF8.GetBytes(instance)))
                 {
-                    Assert.Equal(expectedValidationResult, jsonValidator.Validate(utf8JsonInstance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat }).IsValid);
+                    Assert.Equal(expectedValidationResult, jsonValidator.Validate(utf8JsonInstance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
                 }
             }
         }
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task ValidateByJsonElementSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task ValidateByJsonElementSchema_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
@@ -185,13 +198,13 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
                     }
                 }
 
-                Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { ValidateFormat = false, OutputFormat = outputFormat }).IsValid);
+                Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
             }
         }
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestSuite))]
-        public async Task ValidateByExternalSchemaDocumentPopulator_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public async Task ValidateByExternalSchemaDocumentPopulator_InputFromJsonSchemaTestSuite(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
@@ -209,7 +222,7 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
                 }
             }
 
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat }).IsValid);
+            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ValidateFormat = false, OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
         }
 
         private class TestExternalSchemaDocumentPopulator : IExternalSchemaDocumentPopulator
@@ -239,19 +252,19 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestCasesForFormatKeyword))]
-        public void ValidateByStringSchema_ValidateFormatKeyword(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public void ValidateByStringSchema_ValidateFormatKeyword(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             _testOutputHelper.WriteLine($"Test case description: {testCaseDescription}");
             _testOutputHelper.WriteLine($"Test description: {testDescription}");
 
             var jsonValidator = new JsonValidator(schema, new JsonValidatorOptions{DefaultDialect = dialect, IgnoreResourceIdInUnknownKeyword = ignoreResourceIdFromUnknownKeyword});
 
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ OutputFormat = outputFormat }).IsValid);
+            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions{ OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage}).IsValid);
         }
 
         [Theory]
         [MemberData(nameof(JsonSchemaTestCasesForCustomFormat))]
-        public void Validate_CustomFormatKeyword(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
+        public void Validate_CustomFormatKeyword(DialectKind dialect, string schema, string instance, OutputFormat outputFormat, bool generateErrorMessage, bool ignoreResourceIdFromUnknownKeyword, bool expectedValidationResult, string testCaseDescription, string testDescription)
         {
             FormatRegistry globalFormatRegistry = FormatRegistry.CreateDefaultRegistry();
             globalFormatRegistry.AddFormat("custom_format", () => new TrueToTrueFormatValidator());
@@ -260,7 +273,7 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
             Assert.NotNull(option.GlobalFormatRegistry.GetFormatValidator("custom_format"));
 
             var jsonValidator = new JsonValidator(schema, option);
-            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { OutputFormat = outputFormat }).IsValid);
+            Assert.Equal(expectedValidationResult, jsonValidator.Validate(instance, new JsonSchemaOptions { OutputFormat = outputFormat, GenerateErrorMessages = generateErrorMessage }).IsValid);
         }
 
         /// <summary>
@@ -445,17 +458,21 @@ namespace LateApexEarlySpeed.Json.Schema.UnitTests
                 {
                     foreach (OutputFormat outputFormat in Enum.GetValues<OutputFormat>())
                     {
-                        yield return new object[]
+                        foreach (bool generateErrorMessage in new[]{false, true})
                         {
-                            dialect,
-                            JsonSerializer.Serialize(testCaseParameter.TestCase.JsonSchema),
-                            JsonSerializer.Serialize(test.Instance),
-                            outputFormat,
-                            testCaseParameter.IgnoreResourceIdFromUnknownKeyword,
-                            test.ValidationResult,
-                            testCaseParameter.TestCase.Description,
-                            test.Description
-                        };
+                            yield return new object[]
+                            {
+                                dialect,
+                                JsonSerializer.Serialize(testCaseParameter.TestCase.JsonSchema),
+                                JsonSerializer.Serialize(test.Instance),
+                                outputFormat,
+                                generateErrorMessage,
+                                testCaseParameter.IgnoreResourceIdFromUnknownKeyword,
+                                test.ValidationResult,
+                                testCaseParameter.TestCase.Description,
+                                test.Description
+                            };                            
+                        }
                     }
                 }
             }

--- a/LateApexEarlySpeed.Json.Schema/Common/JsonSchemaOptions.cs
+++ b/LateApexEarlySpeed.Json.Schema/Common/JsonSchemaOptions.cs
@@ -27,7 +27,7 @@ public class JsonSchemaOptions
     public OutputFormat OutputFormat { get; set; }
 
     /// <summary>
-    /// Gets or sets whether human-readable validation error messages are generated. The primary purpose of setting this property to <see langword="false"/> is to reduce allocations in failure-heavy validation workloads.
+    /// Gets or sets a value that defines whether human-readable validation error messages are generated. The primary purpose of setting this property to <see langword="false"/> is to reduce allocations in failure-heavy validation workloads.
     /// The default is <see langword="true"/>.
     /// </summary>
     /// <remarks>

--- a/LateApexEarlySpeed.Json.Schema/Common/JsonSchemaOptions.cs
+++ b/LateApexEarlySpeed.Json.Schema/Common/JsonSchemaOptions.cs
@@ -27,6 +27,15 @@ public class JsonSchemaOptions
     public OutputFormat OutputFormat { get; set; }
 
     /// <summary>
+    /// Gets or sets whether human-readable validation error messages are generated. The primary purpose of setting this property to <see langword="false"/> is to reduce allocations in failure-heavy validation workloads.
+    /// The default is <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="false"/>, validation errors retain their result code, keyword, instance location, and schema locations, but <see cref="ValidationError.ErrorMessage"/> is <see cref="string.Empty"/>.
+    /// </remarks>
+    public bool GenerateErrorMessages { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the <see cref="JsonCollectionEqualityComparer"/> implementation to use when compare JSON arrays.
     /// Default value is <see cref="JsonCollectionEqualityComparer.Equality"/>.
     /// </summary>
@@ -56,6 +65,7 @@ public class JsonSchemaOptions
             ValidateFormat = options.ValidateFormat;
             RegexMatchTimeout = options.RegexMatchTimeout;
             OutputFormat = options.OutputFormat;
+            GenerateErrorMessages = options.GenerateErrorMessages;
             JsonArrayEqualityComparer = options.JsonArrayEqualityComparer;
             JsonStringComparison = options.JsonStringComparison;
         }

--- a/LateApexEarlySpeed.Json.Schema/Common/ValidationResult.cs
+++ b/LateApexEarlySpeed.Json.Schema/Common/ValidationResult.cs
@@ -173,7 +173,9 @@ public class ValidationError
     public string? Keyword { get; init; }
 
     /// <summary>
-    /// The error message to briefly describe failure reason
+    /// Gets the human-readable description of the validation failure.
+    /// Built-in validators return <see cref="string.Empty"/> when
+    /// <see cref="JsonSchemaOptions.GenerateErrorMessages"/> is disabled.
     /// </summary>
     public string ErrorMessage { get; init; }
 
@@ -188,8 +190,12 @@ public class ValidationError
     /// <returns>A string representation of the current <see cref="ValidationError"/></returns>
     public override string ToString()
     {
-        var sb = new StringBuilder(ErrorMessage);
-        sb.AppendLine();
+        var sb = new StringBuilder();
+
+        if (!string.IsNullOrEmpty(ErrorMessage))
+        {
+            sb.AppendLine(ErrorMessage);
+        }
 
         sb.AppendFormat("Instance location (in json pointer format): {0}", InstanceLocation);
         sb.AppendLine();

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/AfterDateTimeExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/AfterDateTimeExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class AfterDateTimeExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data > _after
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotAfterSpecifiedTimePoint, ErrorMessage(data, _after), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotAfterSpecifiedTimePoint, options.GenerateErrorMessages ? ErrorMessage(data, _after) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTime actual, DateTime expectedAfter)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/AfterDateTimeOffsetExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/AfterDateTimeOffsetExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class AfterDateTimeOffsetExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeOffsetFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeOffsetFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data > _after
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotAfterSpecifiedTimePoint, ErrorMessage(data, _after), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotAfterSpecifiedTimePoint, options.GenerateErrorMessages ? ErrorMessage(data, _after) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTimeOffset actual, DateTimeOffset expectedAfter)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/BeforeDateTimeExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/BeforeDateTimeExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class BeforeDateTimeExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data < _before
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotBeforeSpecifiedTimePoint, ErrorMessage(data, _before), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotBeforeSpecifiedTimePoint, options.GenerateErrorMessages ? ErrorMessage(data, _before) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTime actual, DateTime expectedBefore)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/BeforeDateTimeOffsetExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/BeforeDateTimeOffsetExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class BeforeDateTimeOffsetExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeOffsetFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeOffsetFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data < _before
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotBeforeSpecifiedTimePoint, ErrorMessage(data, _before), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotBeforeSpecifiedTimePoint, options.GenerateErrorMessages ? ErrorMessage(data, _before) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTimeOffset actual, DateTimeOffset expectedBefore)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/ContainsKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/ContainsKeyword.cs
@@ -35,7 +35,7 @@ internal class ContainsKeyword : KeywordBase
             }
         }
 
-        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotFoundAnyValidatedArrayItem, ErrorMessage(instance.ToString()), options.ValidationPathStack,
+        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotFoundAnyValidatedArrayItem, options.GenerateErrorMessages ? ErrorMessage(instance.ToString()) : string.Empty, options.ValidationPathStack,
             Name, instance.Location));
     }
 

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/CustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/CustomValidationKeyword.cs
@@ -28,13 +28,13 @@ internal class CustomValidationKeyword<T> : KeywordBase
         }
         catch (Exception)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToDeserialize, $"Failed to deserialize to type: {typeof(T)}", options.ValidationPathStack,
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToDeserialize, options.GenerateErrorMessages ? $"Failed to deserialize to type: {typeof(T)}" : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
         }
 
         return _validator(instanceData)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(instanceData), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(instanceData) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeCustomValidationKeyword.cs
@@ -33,12 +33,12 @@ internal class DateTimeCustomValidationKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return _validator(data)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(data), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(data) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeFormatExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeFormatExtensionKeyword.cs
@@ -29,7 +29,7 @@ internal class DateTimeFormatExtensionKeyword : KeywordBase
 
         return canParse
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     internal static string ErrorMessage()

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeOffsetCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeOffsetCustomValidationKeyword.cs
@@ -33,12 +33,12 @@ internal class DateTimeOffsetCustomValidationKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeOffsetFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeOffsetFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return _validator(data)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(data), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(data) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeOffsetFormatExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/DateTimeOffsetFormatExtensionKeyword.cs
@@ -29,7 +29,7 @@ internal class DateTimeOffsetFormatExtensionKeyword : KeywordBase
 
         return canParse
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     internal static string ErrorMessage()

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/EqualsDateTimeExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/EqualsDateTimeExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class EqualsDateTimeExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data == _value
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, ErrorMessage(data, _value), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, options.GenerateErrorMessages ? ErrorMessage(data, _value) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTime actual, DateTime expectedValue)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/EqualsDateTimeOffsetExtensionKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/EqualsDateTimeOffsetExtensionKeyword.cs
@@ -31,12 +31,12 @@ internal class EqualsDateTimeOffsetExtensionKeyword : KeywordBase
 
         if (!canParse)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, DateTimeOffsetFormatExtensionKeyword.ErrorMessage(), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? DateTimeOffsetFormatExtensionKeyword.ErrorMessage() : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return data == _value
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, ErrorMessage(data, _value), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, options.GenerateErrorMessages ? ErrorMessage(data, _value) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private static string ErrorMessage(DateTimeOffset actual, DateTimeOffset expectedValue)

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/JsonElementBasedObjectCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/JsonElementBasedObjectCustomValidationKeyword.cs
@@ -24,7 +24,7 @@ internal class JsonElementBasedObjectCustomValidationKeyword : KeywordBase
     {
         return _validator(instance.InternalJsonElement)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(instance.InternalJsonElement), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(instance.InternalJsonElement) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NoPropertiesKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NoPropertiesKeyword.cs
@@ -29,7 +29,7 @@ internal class NoPropertiesKeyword : KeywordBase
         {
             if (_propertyBlackList.Contains(property.Name))
             {
-                return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidPropertyName, ErrorMessage(property.Name), options.ValidationPathStack,
+                return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidPropertyName, options.GenerateErrorMessages ? ErrorMessage(property.Name) : string.Empty, options.ValidationPathStack,
                     Name, instance.Location));
             }
         }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NotContainsKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NotContainsKeyword.cs
@@ -30,7 +30,7 @@ internal class NotContainsKeyword : KeywordBase
         {
             if (_schema.Validate(element, options).IsValid)
             {
-                return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.SubSchemaPassedUnexpected, ErrorMessage(element.ToString()), options.ValidationPathStack,
+                return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.SubSchemaPassedUnexpected, options.GenerateErrorMessages ? ErrorMessage(element.ToString()) : string.Empty, options.ValidationPathStack,
                     Name, element.Location));
             }
         }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NumberCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/NumberCustomValidationKeyword.cs
@@ -25,12 +25,12 @@ public abstract class NumberCustomValidationKeyword<T> : KeywordBase
 
         if (!TryGetNumber(instance, out T instanceData))
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, ErrorMessageForTypeConvert(instance.ToString()), options.ValidationPathStack, Name, instance.Location));
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? ErrorMessageForTypeConvert(instance.ToString()) : string.Empty, options.ValidationPathStack, Name, instance.Location));
         }
 
         return _validator(instanceData)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(instanceData), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(instanceData) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/ObjectCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/ObjectCustomValidationKeyword.cs
@@ -36,13 +36,13 @@ internal class ObjectCustomValidationKeyword : KeywordBase
         }
         catch (Exception)
         {
-            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToDeserialize, $"Failed to deserialize to type: {_type}", options.ValidationPathStack,
+            return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToDeserialize, options.GenerateErrorMessages ? $"Failed to deserialize to type: {_type}" : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
         }
 
         return _validator(instanceData)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(instanceData), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(instanceData) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/StringCustomValidationKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/FluentGenerator/ExtendedKeywords/StringCustomValidationKeyword.cs
@@ -30,7 +30,7 @@ public class StringCustomValidationKeyword : KeywordBase
         string instanceData = instance.GetString()!;
         return _validator(instanceData)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, _errorMessageFunc(instanceData), options.ValidationPathStack,
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedForCustomValidation, options.GenerateErrorMessages ? _errorMessageFunc(instanceData) : string.Empty, options.ValidationPathStack,
                 Name, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/JSchema/BooleanJsonSchema.cs
+++ b/LateApexEarlySpeed.Json.Schema/JSchema/BooleanJsonSchema.cs
@@ -21,7 +21,7 @@ internal class BooleanJsonSchema : JsonSchema
     {
         return AlwaysValid 
             ? ValidationResult.ValidResult 
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.AlwaysFailedJsonSchema, ErrorMessage(), options.ValidationPathStack, null, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.AlwaysFailedJsonSchema, options.GenerateErrorMessages ? ErrorMessage() : string.Empty, options.ValidationPathStack, null, instance.Location));
     }
 
     public static string ErrorMessage()

--- a/LateApexEarlySpeed.Json.Schema/JSchema/BooleanJsonSchemaDocument.cs
+++ b/LateApexEarlySpeed.Json.Schema/JSchema/BooleanJsonSchemaDocument.cs
@@ -19,6 +19,6 @@ internal class BooleanJsonSchemaDocument : IJsonSchemaDocument
 
     public ValidationResult DoValidation(JsonInstanceElement instance, JsonSchemaOptions options)
     {
-        return AlwaysValid ? ValidationResult.ValidResult : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.AlwaysFailedJsonSchema, "Boolean false json schema document occurs", null, null, instance.Location));
+        return AlwaysValid ? ValidationResult.ValidResult : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.AlwaysFailedJsonSchema, options.GenerateErrorMessages ? "Boolean false json schema document occurs" : string.Empty, null, null, instance.Location));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/Keywords/AnyOfKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/AnyOfKeyword.cs
@@ -88,7 +88,7 @@ internal class AnyOfKeyword : KeywordBase, ISubSchemaCollection, ISchemaContaine
             {
                 if (_fastReturnResult is null)
                 {
-                    var curError = new ValidationError(ResultCode.AllSubSchemaFailed, ErrorMessage(), _options.ValidationPathStack, _anyOfKeyword.Name, _instance.Location);
+                    var curError = new ValidationError(ResultCode.AllSubSchemaFailed, _options.GenerateErrorMessages ? ErrorMessage() : string.Empty, _options.ValidationPathStack, _anyOfKeyword.Name, _instance.Location);
 
                     return ResultTuple.Invalid(curError);
                 }

--- a/LateApexEarlySpeed.Json.Schema/Keywords/ArrayContainsValidator.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/ArrayContainsValidator.cs
@@ -113,7 +113,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
                     return ResultTuple.Valid();
                 }
 
-                ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, GetFailedMinContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MinContains.Value), MinContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, _options.GenerateErrorMessages ? GetFailedMinContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MinContains.Value) : string.Empty, MinContainsKeywordName, _options.ValidationPathStack, _instance.Location);
                 return ResultTuple.Invalid(error);
             }
         }
@@ -154,7 +154,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
                 ValidationResult? fastResult = null;
                 if (_validatedItemCount > _arrayContainsValidator.MaxContains)
                 {
-                    ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, GetFailedMaxContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MaxContains.Value), MaxContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                    ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, _options.GenerateErrorMessages ? GetFailedMaxContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MaxContains.Value) : string.Empty, MaxContainsKeywordName, _options.ValidationPathStack, _instance.Location);
                     fastResult = ValidationResult.SingleErrorFailedResult(error);
                 }
 
@@ -171,7 +171,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
             {
                 if (_validatedItemCount > _arrayContainsValidator.MaxContains)
                 {
-                    ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, GetFailedMaxContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MaxContains.Value), MaxContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                    ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, _options.GenerateErrorMessages ? GetFailedMaxContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MaxContains.Value) : string.Empty, MaxContainsKeywordName, _options.ValidationPathStack, _instance.Location);
                     return ResultTuple.Invalid(error);
                 }
 
@@ -179,7 +179,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
                 {
                     if (_validatedItemCount < _arrayContainsValidator.MinContains)
                     {
-                        ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, GetFailedMinContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MinContains.Value), MinContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                        ValidationError error = CreateValidationErrorWithLocation(ResultCode.ValidatedArrayItemsCountOutOfRange, _options.GenerateErrorMessages ? GetFailedMinContainsErrorMessage(_instance.ToString(), _arrayContainsValidator.MinContains.Value) : string.Empty, MinContainsKeywordName, _options.ValidationPathStack, _instance.Location);
 
                         return ResultTuple.Invalid(error);
                     }
@@ -188,7 +188,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
                 {
                     if (_validatedItemCount == 0)
                     {
-                        ValidationError error = CreateValidationErrorWithLocation(ResultCode.NotFoundAnyValidatedArrayItem, GetFailedContainsErrorMessage(_instance.ToString()), ContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                        ValidationError error = CreateValidationErrorWithLocation(ResultCode.NotFoundAnyValidatedArrayItem, _options.GenerateErrorMessages ? GetFailedContainsErrorMessage(_instance.ToString()) : string.Empty, ContainsKeywordName, _options.ValidationPathStack, _instance.Location);
 
                         return ResultTuple.Invalid(error);
                     }
@@ -256,7 +256,7 @@ internal class ArrayContainsValidator : ISchemaContainerValidationNode, IJsonSch
                     return ResultTuple.Valid();
                 }
 
-                ValidationError curError = CreateValidationErrorWithLocation(ResultCode.NotFoundAnyValidatedArrayItem, GetFailedContainsErrorMessage(_instance.ToString()), ContainsKeywordName, _options.ValidationPathStack, _instance.Location);
+                ValidationError curError = CreateValidationErrorWithLocation(ResultCode.NotFoundAnyValidatedArrayItem, _options.GenerateErrorMessages ? GetFailedContainsErrorMessage(_instance.ToString()) : string.Empty, ContainsKeywordName, _options.ValidationPathStack, _instance.Location);
 
                 return ResultTuple.Invalid(curError);
             }

--- a/LateApexEarlySpeed.Json.Schema/Keywords/ArrayLengthKeywordBase.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/ArrayLengthKeywordBase.cs
@@ -20,7 +20,7 @@ internal abstract class ArrayLengthKeywordBase : KeywordBase, IBenchmarkValueKey
 
         return IsSizeInRange(instanceLength)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.ArrayLengthOutOfRange, GetErrorMessage(instanceLength), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.ArrayLengthOutOfRange, options.GenerateErrorMessages ? GetErrorMessage(instanceLength) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     protected abstract bool IsSizeInRange(int instanceArrayLength);

--- a/LateApexEarlySpeed.Json.Schema/Keywords/ConstKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/ConstKeyword.cs
@@ -30,6 +30,6 @@ internal class ConstKeyword : KeywordBase
 
         Debug.Assert(equivalentResult.DetailedMessage is not null);
         Debug.Assert(equivalentResult.OtherLocation is not null);
-        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, equivalentResult.DetailedMessage, options.ValidationPathStack, Name, equivalentResult.OtherLocation));
+        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.UnexpectedValue, options.GenerateErrorMessages ? equivalentResult.DetailedMessage : string.Empty, options.ValidationPathStack, Name, equivalentResult.OtherLocation));
     }
 }

--- a/LateApexEarlySpeed.Json.Schema/Keywords/DependentRequiredKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/DependentRequiredKeyword.cs
@@ -60,7 +60,7 @@ internal class DependentRequiredKeyword : KeywordBase
                         {
                             _fastReturnResult = ValidationResult.SingleErrorFailedResult(new ValidationError(
                                 ResultCode.NotFoundRequiredDependentProperty,
-                                ErrorMessage(dependentProperty.Key, requiredProp),
+                                _options.GenerateErrorMessages ? ErrorMessage(dependentProperty.Key, requiredProp) : string.Empty,
                                 _options.ValidationPathStack,
                                 _keywordName,
                                 _instance.Location));

--- a/LateApexEarlySpeed.Json.Schema/Keywords/EnumKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/EnumKeyword.cs
@@ -28,7 +28,7 @@ internal class EnumKeyword : KeywordBase
             }
         }
 
-        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotFoundInAllowedList, ErrorMessage(instance.ToString()), options.ValidationPathStack, Name, instance.Location));
+        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NotFoundInAllowedList, options.GenerateErrorMessages ? ErrorMessage(instance.ToString()) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     internal static string ErrorMessage(string instanceJsonText)

--- a/LateApexEarlySpeed.Json.Schema/Keywords/FormatKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/FormatKeyword.cs
@@ -32,7 +32,7 @@ public class FormatKeyword : KeywordBase
 
         return _formatValidator.Validate(instance.GetString()!)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, ErrorMessage(Format), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidFormat, options.GenerateErrorMessages ? ErrorMessage(Format) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     public static string ErrorMessage(string format)

--- a/LateApexEarlySpeed.Json.Schema/Keywords/MultipleOfKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/MultipleOfKeyword.cs
@@ -59,7 +59,7 @@ internal class MultipleOfKeyword : KeywordBase
         MultipleOfResult multipleOfResult = _multipleOfChecker.Check(instance.InternalJsonElement, options.GenerateErrorMessages);
         return multipleOfResult.IsSuccess
             ? ValidationResult.ValidResult 
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToMultiple, options.GenerateErrorMessages ? multipleOfResult.ErrorMessage : string.Empty, options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToMultiple, multipleOfResult.ErrorMessage, options.ValidationPathStack, Name, instance.Location));
     }
 }
 

--- a/LateApexEarlySpeed.Json.Schema/Keywords/MultipleOfKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/MultipleOfKeyword.cs
@@ -56,10 +56,10 @@ internal class MultipleOfKeyword : KeywordBase
             return ValidationResult.ValidResult;
         }
 
-        MultipleOfResult multipleOfResult = _multipleOfChecker.Check(instance.InternalJsonElement);
+        MultipleOfResult multipleOfResult = _multipleOfChecker.Check(instance.InternalJsonElement, options.GenerateErrorMessages);
         return multipleOfResult.IsSuccess
             ? ValidationResult.ValidResult 
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToMultiple, multipleOfResult.ErrorMessage, options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.FailedToMultiple, options.GenerateErrorMessages ? multipleOfResult.ErrorMessage : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 }
 
@@ -75,7 +75,7 @@ internal class DecimalMultipleOfChecker : IMultipleOfChecker
         _multipleOf = multipleOf;
     }
 
-    public MultipleOfResult Check(JsonElement instance)
+    public MultipleOfResult Check(JsonElement instance, bool generateErrorMessage)
     {
         Debug.Assert(_multipleOf > 0);
 
@@ -88,7 +88,7 @@ internal class DecimalMultipleOfChecker : IMultipleOfChecker
             decimal actualTolerance = _multipleOf * DecimalTolerance;
             return remainder < actualTolerance || Math.Abs(remainder - _multipleOf) < actualTolerance
                 ? MultipleOfResult.Success()
-                : MultipleOfResult.Fail(ErrorMessage(decimalInstance, _multipleOf));
+                : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(decimalInstance, _multipleOf) : string.Empty);
         }
         else
         {
@@ -103,7 +103,7 @@ internal class DecimalMultipleOfChecker : IMultipleOfChecker
             double actualTolerance = multipleOf * DoubleTolerance;
             return remainder < actualTolerance || Math.Abs(remainder - multipleOf) < actualTolerance
                 ? MultipleOfResult.Success()
-                : MultipleOfResult.Fail(ErrorMessage(doubleInstance, _multipleOf));
+                : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(doubleInstance, _multipleOf) : string.Empty);
         }
     }
 
@@ -127,7 +127,7 @@ internal class ULongMultipleOfChecker : IMultipleOfChecker
         _multipleOf = multipleOf;
     }
 
-    public MultipleOfResult Check(JsonElement instance)
+    public MultipleOfResult Check(JsonElement instance, bool generateErrorMessage)
     {
         Debug.Assert(_multipleOf != 0);
 
@@ -137,25 +137,25 @@ internal class ULongMultipleOfChecker : IMultipleOfChecker
             {
                 return longInstance == 0 
                     ? MultipleOfResult.Success() 
-                    : MultipleOfResult.Fail(ErrorMessage(longInstance, _multipleOf));
+                    : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(longInstance, _multipleOf) : string.Empty);
             }
 
             return longInstance % (long)_multipleOf == 0 
                 ? MultipleOfResult.Success() 
-                : MultipleOfResult.Fail(ErrorMessage(longInstance, _multipleOf));
+                : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(longInstance, _multipleOf) : string.Empty);
         }
 
         if (instance.TryGetUInt64(out ulong ulongInstance))
         {
             return ulongInstance % _multipleOf == 0
                 ? MultipleOfResult.Success()
-                : MultipleOfResult.Fail(ErrorMessage(ulongInstance, _multipleOf));
+                : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(ulongInstance, _multipleOf) : string.Empty);
         }
 
         // Now the instance should be float point number
         double doubleInstance = instance.GetDouble();
         Debug.Assert(doubleInstance % _multipleOf != 0);
-        return MultipleOfResult.Fail(ErrorMessage(doubleInstance, _multipleOf));
+        return MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(doubleInstance, _multipleOf) : string.Empty);
     }
 
     public void WriteMultipleOfValue(Utf8JsonWriter writer)
@@ -180,7 +180,7 @@ internal class DoubleMultipleOfChecker : IMultipleOfChecker
         _multipleOf = multipleOf;
     }
 
-    public MultipleOfResult Check(JsonElement instance)
+    public MultipleOfResult Check(JsonElement instance, bool generateErrorMessage)
     {
         Debug.Assert(_multipleOf > 0);
 
@@ -197,7 +197,7 @@ internal class DoubleMultipleOfChecker : IMultipleOfChecker
         double actualTolerance = _multipleOf * Tolerance;
         return remainder < actualTolerance || Math.Abs(remainder - _multipleOf) < actualTolerance
             ? MultipleOfResult.Success()
-            : MultipleOfResult.Fail(ErrorMessage(instanceValue, _multipleOf));
+            : MultipleOfResult.Fail(generateErrorMessage ? ErrorMessage(instanceValue, _multipleOf) : string.Empty);
     }
 
     public void WriteMultipleOfValue(Utf8JsonWriter writer)
@@ -213,7 +213,7 @@ internal class DoubleMultipleOfChecker : IMultipleOfChecker
 
 internal interface IMultipleOfChecker
 {
-    MultipleOfResult Check(JsonElement instance);
+    MultipleOfResult Check(JsonElement instance, bool generateErrorMessage);
     void WriteMultipleOfValue(Utf8JsonWriter writer);
 }
 

--- a/LateApexEarlySpeed.Json.Schema/Keywords/NotKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/NotKeyword.cs
@@ -26,7 +26,7 @@ internal class NotKeyword : KeywordBase, ISchemaContainerElement, ISingleSubSche
 
         if (validationResult.IsValid)
         {
-            var curError = new ValidationError(ResultCode.SubSchemaPassedUnexpected, ErrorMessage(instance.ToString()), options.ValidationPathStack, Name, instance.Location);
+            var curError = new ValidationError(ResultCode.SubSchemaPassedUnexpected, options.GenerateErrorMessages ? ErrorMessage(instance.ToString()) : string.Empty, options.ValidationPathStack, Name, instance.Location);
 
             if (options.OutputFormat == OutputFormat.FailFast)
             {

--- a/LateApexEarlySpeed.Json.Schema/Keywords/NumberRangeKeywordBase.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/NumberRangeKeywordBase.cs
@@ -25,7 +25,7 @@ internal abstract class NumberRangeKeywordBase : KeywordBase
 
         return _benchmarkChecker.IsInRange(instance)
             ? ValidationResult.ValidResult 
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NumberOutOfRange, _benchmarkChecker.GetErrorMessage(instance), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.NumberOutOfRange, options.GenerateErrorMessages ? _benchmarkChecker.GetErrorMessage(instance) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     protected abstract class NonDecimalBenchmarkCheckerBase : IBenchmarkChecker

--- a/LateApexEarlySpeed.Json.Schema/Keywords/OneOfKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/OneOfKeyword.cs
@@ -69,7 +69,7 @@ internal class OneOfKeyword : KeywordBase, ISubSchemaCollection, ISchemaContaine
                 ValidationResult? fastResult = null;
                 if (_validatedSchemaCount > 1)
                 {
-                    var error = new ValidationError(ResultCode.MoreThanOnePassedSchemaFound, "More than one schema validate instance", _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
+                    var error = new ValidationError(ResultCode.MoreThanOnePassedSchemaFound, _options.GenerateErrorMessages ? "More than one schema validate instance" : string.Empty, _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
                     fastResult = ValidationResult.SingleErrorFailedResult(error);
                 }
 
@@ -86,14 +86,14 @@ internal class OneOfKeyword : KeywordBase, ISubSchemaCollection, ISchemaContaine
             {
                 if (_validatedSchemaCount == 0)
                 {
-                    var error = new ValidationError(ResultCode.AllSubSchemaFailed, "Instance failed validation against all schemas", _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
+                    var error = new ValidationError(ResultCode.AllSubSchemaFailed, _options.GenerateErrorMessages ? "Instance failed validation against all schemas" : string.Empty, _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
 
                     return ResultTuple.Invalid(error);
                 }
 
                 if (_validatedSchemaCount > 1)
                 {
-                    var error = new ValidationError(ResultCode.MoreThanOnePassedSchemaFound, "More than one schema validate instance", _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
+                    var error = new ValidationError(ResultCode.MoreThanOnePassedSchemaFound, _options.GenerateErrorMessages ? "More than one schema validate instance" : string.Empty, _options.ValidationPathStack, _oneOfKeyword.Name, _instance.Location);
 
                     return ResultTuple.Invalid(error);
                 }

--- a/LateApexEarlySpeed.Json.Schema/Keywords/PatternKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/PatternKeyword.cs
@@ -27,7 +27,7 @@ internal class PatternKeyword : KeywordBase
         string instanceText = instance.GetString()!;
         return RegexMatcher.IsMatch(Pattern, instanceText, options.RegexMatchTimeout)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.RegexNotMatch, ErrorMessage(Pattern, instanceText), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.RegexNotMatch, options.GenerateErrorMessages ? ErrorMessage(Pattern, instanceText) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     public static string ErrorMessage(string pattern, string instanceText)

--- a/LateApexEarlySpeed.Json.Schema/Keywords/PropertiesSizeKeywordBase.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/PropertiesSizeKeywordBase.cs
@@ -20,7 +20,7 @@ internal abstract class PropertiesSizeKeywordBase : KeywordBase, IBenchmarkValue
 
         return IsSizeInRange(instanceProperties)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.PropertiesOutOfRange, GetErrorMessage(instanceProperties), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.PropertiesOutOfRange, options.GenerateErrorMessages ? GetErrorMessage(instanceProperties) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     protected abstract bool IsSizeInRange(int instanceProperties);

--- a/LateApexEarlySpeed.Json.Schema/Keywords/PropertyNamesKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/PropertyNamesKeyword.cs
@@ -54,7 +54,7 @@ internal class PropertyNamesKeyword : KeywordBase, ISchemaContainerElement, ISin
                 ValidationResult validationResult = _propertyNamesKeyword.Schema.Validate(new JsonInstanceElement(JsonSerializer.SerializeToElement(jsonProperty.Name), LinkedListBasedImmutableJsonPointer.Empty), _options);
                 if (!validationResult.IsValid)
                 {
-                    _fastReturnError = new ValidationError(ResultCode.InvalidPropertyName, ErrorMessage(jsonProperty.Name), _options.ValidationPathStack, _propertyNamesKeyword.Name, _instance.Location);
+                    _fastReturnError = new ValidationError(ResultCode.InvalidPropertyName, _options.GenerateErrorMessages ? ErrorMessage(jsonProperty.Name) : string.Empty, _options.ValidationPathStack, _propertyNamesKeyword.Name, _instance.Location);
                 }
 
                 ValidationResult? fastResult = _fastReturnError is null

--- a/LateApexEarlySpeed.Json.Schema/Keywords/RequiredKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/RequiredKeyword.cs
@@ -67,7 +67,7 @@ internal class RequiredKeyword : KeywordBase
                 }
                 else
                 {
-                    var curError = new ValidationError(ResultCode.NotFoundRequiredProperty, ErrorMessage(requiredProperty), _options.ValidationPathStack, _requiredKeyword.Name, _instance.Location);
+                    var curError = new ValidationError(ResultCode.NotFoundRequiredProperty, _options.GenerateErrorMessages ? ErrorMessage(requiredProperty) : string.Empty, _options.ValidationPathStack, _requiredKeyword.Name, _instance.Location);
                     validationResult = ValidationResult.SingleErrorFailedResult(curError);
 
                     _fastReturnResult = validationResult;

--- a/LateApexEarlySpeed.Json.Schema/Keywords/StringLengthKeywordBase.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/StringLengthKeywordBase.cs
@@ -20,7 +20,7 @@ internal abstract class StringLengthKeywordBase : KeywordBase, IBenchmarkValueKe
         int instanceStringLength = new StringInfo(instance.GetString()!).LengthInTextElements;
         return IsStringLengthInRange(instanceStringLength)
             ? ValidationResult.ValidResult
-            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.StringLengthOutOfRange, GetErrorMessage(instanceStringLength), options.ValidationPathStack, Name, instance.Location));
+            : ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.StringLengthOutOfRange, options.GenerateErrorMessages ? GetErrorMessage(instanceStringLength) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     protected abstract bool IsStringLengthInRange(int instanceStringLength);

--- a/LateApexEarlySpeed.Json.Schema/Keywords/TypeKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/TypeKeyword.cs
@@ -39,7 +39,7 @@ internal class TypeKeyword : KeywordBase
             }
         }
 
-        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidTokenKind, GetErrorMessage(instance.ValueKind), options.ValidationPathStack, Name, instance.Location));
+        return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.InvalidTokenKind, options.GenerateErrorMessages ? GetErrorMessage(instance.ValueKind) : string.Empty, options.ValidationPathStack, Name, instance.Location));
     }
 
     private string GetErrorMessage(JsonValueKind actualKind)

--- a/LateApexEarlySpeed.Json.Schema/Keywords/UniqueItemsKeyword.cs
+++ b/LateApexEarlySpeed.Json.Schema/Keywords/UniqueItemsKeyword.cs
@@ -33,7 +33,7 @@ internal class UniqueItemsKeyword : KeywordBase
             {
                 if (items[j].Equivalent(curItem, options.JsonArrayEqualityComparer, options.JsonStringComparison).Result)
                 {
-                    return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.DuplicatedArrayItems, ErrorMessage(curItem.ToString(), i, j), options.ValidationPathStack, Name, instance.Location));
+                    return ValidationResult.SingleErrorFailedResult(new ValidationError(ResultCode.DuplicatedArrayItems, options.GenerateErrorMessages ? ErrorMessage(curItem.ToString(), i, j) : string.Empty, options.ValidationPathStack, Name, instance.Location));
                 }
             }
         }


### PR DESCRIPTION
this is first version to resolve concern of issue #96 , per [issue comment](https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema/issues/96#issuecomment-5206691956)

@hahahahahaiyiwen I have finished this initial improvement version: add 'GenerateErrorMessages' option.

I have run benchmark, seems this code change does not change benchmark result based on official test suite data comparing master version when `GenerateErrorMessages` is true (default value) - that is good.

and benchmark results difference between `GenerateErrorMessages` status are (still based on test suite data):

`GenerateErrorMessages `is true (default)
| Method                             | testValidationResult | Mean       | Error    | StdDev   | Gen0     | Gen1   | Allocated |
|----------------------------------- |--------------------- |-----------:|---------:|---------:|---------:|-------:|----------:|
| CreateNewSchema_LateApexEarlySpeed | ?                    | 1,399.4 us | 21.66 us | 18.08 us | 164.0625 |      - | 2022.8 KB |
| ReuseSchema_LateApexEarlySpeed     | Positive             |   213.2 us |  3.66 us |  3.42 us |  44.6777 | 0.2441 | 548.77 KB |
| ReuseSchema_LateApexEarlySpeed     | Negative             |   106.8 us |  2.13 us |  1.99 us |  26.0010 | 0.1221 | 319.41 KB |
| ReuseSchema_LateApexEarlySpeed     | All                  |   328.7 us |  6.53 us |  6.41 us |  70.8008 |      - | 867.78 KB |

`GenerateErrorMessages` is false
| Method                             | testValidationResult | Mean        | Error     | StdDev    | Gen0     | Gen1   | Allocated |
|----------------------------------- |--------------------- |------------:|----------:|----------:|---------:|-------:|----------:|
| CreateNewSchema_LateApexEarlySpeed | ?                    | 1,363.84 us | 26.437 us | 32.467 us | 160.1563 |      - | 1977.3 KB |
| ReuseSchema_LateApexEarlySpeed     | Positive             |   206.32 us |  3.105 us |  2.753 us |  44.1895 | 0.2441 | 542.82 KB |
| ReuseSchema_LateApexEarlySpeed     | Negative             |    91.29 us |  1.754 us |  1.641 us |  22.8271 | 0.1221 | 279.94 KB |
| ReuseSchema_LateApexEarlySpeed     | All                  |   308.24 us |  6.099 us |  6.526 us |  66.8945 |      - | 822.34 KB |

you can try them based on your invalid data later.